### PR TITLE
Add additional linters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ You can install *MeshLode* using pip with
 You can then ``import meshlode`` and use it in your projects!
 
 We also provide bindings to `metatensor
-<https://lab-cosmo.github.io/metatensor/latest/>`_ which can enable as an optional
-dependencies via
+<https://lab-cosmo.github.io/metatensor/latest/>`_ which can optionally be installed
+together and used as ``meshlode.metatensor`` via
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,27 +53,17 @@ documentation = "http://meshlode.readthedocs.io"
 repository = "https://github.com/ceriottm/MeshLODE"
 issues = "https://github.com/ceriottm/MeshLODE/issues"
 
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools.dynamic]
-version = {attr = "meshlode.__version__"}
-
-[tool.coverage.run]
-branch = true
-data_file = 'tests/.coverage'
-
 [tool.coverage.report]
 include = [
     "src/meshlode/*"
 ]
 
+[tool.coverage.run]
+branch = true
+data_file = 'tests/.coverage'
+
 [tool.coverage.xml]
 output = 'tests/coverage.xml'
-
-[tool.pytest.ini_options]
-python_files = ["*.py"]
-testpaths = ["tests"]
 
 [tool.isort]
 skip = "__init__.py"
@@ -83,3 +73,16 @@ indent = 4
 include_trailing_comma = true
 lines_after_imports = 2
 known_first_party = "meshlode"
+
+[tool.mypy]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+python_files = ["*.py"]
+testpaths = ["tests"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.dynamic]
+version = {attr = "meshlode.__version__"}

--- a/src/meshlode/calculators/meshpotential.py
+++ b/src/meshlode/calculators/meshpotential.py
@@ -57,7 +57,7 @@ class MeshPotential(torch.nn.Module):
         self,
         atomic_smearing: float,
         mesh_spacing: Optional[float] = None,
-        interpolation_order: Optional[float] = 4,
+        interpolation_order: Optional[int] = 4,
         subtract_self: Optional[bool] = False,
     ):
         super().__init__()

--- a/tox.ini
+++ b/tox.ini
@@ -67,34 +67,35 @@ commands_post =
 
 [testenv:lint]
 description = Run linters and type checks
-skip_install = true
+package = skip
 deps =
     black
     blackdoc
     flake8
     flake8-bugbear
     flake8-sphinx-links
+    mypy
     isort
     sphinx-lint
 commands =
     flake8 {[tox]lint_folders}
     black --check --diff {[tox]lint_folders}
-    blackdoc --check --diff {[tox]lint_folders}
+    blackdoc --check --diff {[tox]lint_folders} "{toxinidir}/README.rst"
     isort --check-only --diff {[tox]lint_folders}
+    mypy src/meshlode
     sphinx-lint --enable line-too-long --max-line-length 88 \
-    -i "{toxinidir}/docs/src/examples" \
-    {[tox]lint_folders} "{toxinidir}/README.rst"
+        -i {[tox]lint_folders} "{toxinidir}/README.rst"
 
 [testenv:format]
 description = Abuse tox to do actual formatting on all files.
-skip_install = true
+package = skip
 deps =
     black
     blackdoc
     isort
 commands =
     black {[tox]lint_folders}
-    blackdoc {[tox]lint_folders}
+    blackdoc {[tox]lint_folders} "{toxinidir}/README.rst"
     isort {[tox]lint_folders}
 
 [testenv:docs]


### PR DESCRIPTION
+ `mypy` for checking typehints
+ `blackdoc` for README file
+ sort `[tools.xxx]` in `pyproject.toml` alphabetically

Also I added the comment from @kvhuguenin which I missed in #5...

<!-- readthedocs-preview meshlode start -->
----
:books: Documentation preview :books:: https://meshlode--6.org.readthedocs.build/en/6/

<!-- readthedocs-preview meshlode end -->