### PR TITLE
add `all_atomic_numbers` flag

### DIFF
--- a/examples/library-tutorial.py
+++ b/examples/library-tutorial.py
@@ -55,9 +55,9 @@ def sliceplot(mesh, sz=12, cmap="viridis", vmin=None, vmax=None):
 #
 
 positions = torch.tensor([[0, 0, 0], [0.5, 0.5, 0.5]]) * 4
-atomic_numbers = torch.tensor([55, 17])  # Cs and Cl
+atomic_types = torch.tensor([55, 17])  # Cs and Cl
 cell = torch.eye(3) * 4
-ase_frame = ase.Atoms(positions=positions, cell=cell, numbers=atomic_numbers).repeat(
+ase_frame = ase.Atoms(positions=positions, cell=cell, numbers=atomic_types).repeat(
     [2, 2, 2]
 )
 ase_frame.positions[:] += np.random.normal(size=ase_frame.positions.shape) * 0.1

--- a/examples/madelung.py
+++ b/examples/madelung.py
@@ -20,11 +20,11 @@ import meshlode
 # values. MeshPotential by default outputs the species sorted according to the atomic
 # number. Thus, we input the compound "CsCl" and "ClCs" since Cl and Cs have atomic
 # numbers 17 and 55, respectively.
-atomic_numbers = torch.tensor([17, 55])  # Cl and Cs
+atomic_types = torch.tensor([17, 55])  # Cl and Cs
 charges = torch.tensor([-1.0, 1.0])
 cell = torch.eye(3)
 positions = torch.tensor([[0, 0, 0], [0.5, 0.5, 0.5]])
-frame = meshlode.System(species=atomic_numbers, positions=positions, cell=torch.eye(3))
+frame = meshlode.System(species=atomic_types, positions=positions, cell=torch.eye(3))
 
 # %%
 # Define the expected values of the energy
@@ -105,8 +105,8 @@ potential_metatensor = MP.compute(frame)
 # of the "potentials" weighted by the charges of the atoms.
 
 atomic_energies_metatensor = torch.zeros((n_atoms, 1))
-for idx_c, c in enumerate(atomic_numbers):
-    for idx_n, n in enumerate(atomic_numbers):
+for idx_c, c in enumerate(atomic_types):
+    for idx_n, n in enumerate(atomic_types):
         # Take the coefficients with the correct center atom and neighbor atom species
         block = potential_metatensor.block(
             {"center_type": int(c), "neighbor_type": int(n)}

--- a/tests/calculators/test_meshpotential.py
+++ b/tests/calculators/test_meshpotential.py
@@ -44,15 +44,15 @@ def test_interpolation_order_error():
         MeshPotential(atomic_smearing=1, interpolation_order=10)
 
 
-def test_all_atomic_numbers():
-    descriptor = MeshPotential(atomic_smearing=0.1, all_atomic_numbers=[8, 55, 17])
+def test_all_atomic_types():
+    descriptor = MeshPotential(atomic_smearing=0.1, all_atomic_types=[8, 55, 17])
     values = descriptor.compute(cscl_system())
     assert values.shape == (2, 3)
     assert torch.equal(values[:, 0], torch.zeros(2))
 
 
-def test_all_atomic_numbers_error():
-    descriptor = MeshPotential(atomic_smearing=0.1, all_atomic_numbers=[17])
+def test_all_atomic_types_error():
+    descriptor = MeshPotential(atomic_smearing=0.1, all_atomic_types=[17])
     with pytest.raises(ValueError, match="Global list of atomic numbers"):
         descriptor.compute(cscl_system())
 

--- a/tests/metatensor/test_madelung.py
+++ b/tests/metatensor/test_madelung.py
@@ -44,7 +44,7 @@ class TestMadelung:
         # closest Na-Cl pair is exactly 1. The cubic unit cell
         # in these units would have a length of 2.
         d["NaCl"]["symbols"] = ["Na", "Cl"]
-        d["NaCl"]["atomic_numbers"] = torch.tensor([11, 17])
+        d["NaCl"]["atomic_types"] = torch.tensor([11, 17])
         d["NaCl"]["charges"] = torch.tensor([[1.0, -1]]).T
         d["NaCl"]["positions"] = torch.tensor([[0, 0, 0], [1.0, 0, 0]])
         d["NaCl"]["cell"] = torch.tensor([[0, 1.0, 1], [1, 0, 1], [1, 1, 0]])
@@ -56,7 +56,7 @@ class TestMadelung:
         # The closest Cs-Cl distance is sqrt(3)/2. We thus divide
         # the Madelung constant by this value to match the reference.
         d["CsCl"]["symbols"] = ["Cs", "Cl"]
-        d["CsCl"]["atomic_numbers"] = torch.tensor([55, 17])
+        d["CsCl"]["atomic_types"] = torch.tensor([55, 17])
         d["CsCl"]["charges"] = torch.tensor([[1.0, -1]]).T
         d["CsCl"]["positions"] = torch.tensor([[0, 0, 0], [0.5, 0.5, 0.5]])
         d["CsCl"]["cell"] = torch.eye(3)
@@ -70,7 +70,7 @@ class TestMadelung:
         # If, on the other han_pylode_without_centerd, we set the lattice constant of
         # the cubic cell equal to 1, the Zn-S distance is sqrt(3)/4.
         d["ZnS"]["symbols"] = ["S", "Zn"]
-        d["ZnS"]["atomic_numbers"] = torch.tensor([16, 30])
+        d["ZnS"]["atomic_types"] = torch.tensor([16, 30])
         d["ZnS"]["charges"] = torch.tensor([[1.0, -1]]).T
         d["ZnS"]["positions"] = torch.tensor([[0, 0, 0], [0.5, 0.5, 0.5]])
         d["ZnS"]["cell"] = torch.tensor([[0, 1.0, 1], [1, 0, 1], [1, 1, 0]])
@@ -80,7 +80,7 @@ class TestMadelung:
         u = torch.tensor([3 / 8])
         c = torch.sqrt(1 / u)
         d["ZnSO4"]["symbols"] = ["S", "Zn", "S", "Zn"]
-        d["ZnSO4"]["atomic_numbers"] = torch.tensor([16, 30, 16, 30])
+        d["ZnSO4"]["atomic_types"] = torch.tensor([16, 30, 16, 30])
         d["ZnSO4"]["charges"] = torch.tensor([[1.0, -1, 1, -1]]).T
         d["ZnSO4"]["positions"] = torch.tensor(
             [
@@ -183,13 +183,13 @@ class TestMadelung:
         dic = crystal_dictionary[crystal_name]
         positions = dic["positions"] * scaling_factor
         cell = dic["cell"] * scaling_factor
-        atomic_numbers = dic["atomic_numbers"]
+        atomic_types = dic["atomic_types"]
         charges = dic["charges"]
         madelung = dic["madelung"] / scaling_factor
         mesh_spacing = atomic_smearing / 2 * scaling_factor
         smearing_eff = atomic_smearing * scaling_factor
         n_atoms = len(positions)
-        frame = System(species=atomic_numbers, positions=positions, cell=cell)
+        frame = System(species=atomic_types, positions=positions, cell=cell)
         MP = meshlode_metatensor.MeshPotential(
             atomic_smearing=smearing_eff,
             mesh_spacing=mesh_spacing,
@@ -200,8 +200,8 @@ class TestMadelung:
 
         # Compute the actual potential from the features
         energies = torch.zeros((n_atoms, 1))
-        for idx_c, c in enumerate(atomic_numbers):
-            for idx_n, n in enumerate(atomic_numbers):
+        for idx_c, c in enumerate(atomic_types):
+            for idx_n, n in enumerate(atomic_types):
                 block = potentials_mesh.block(
                     {"center_type": int(c), "neighbor_type": int(n)}
                 )

--- a/tests/metatensor/test_metatensor_meshpotential.py
+++ b/tests/metatensor/test_metatensor_meshpotential.py
@@ -29,14 +29,14 @@ def descriptor() -> meshlode_metatensor.MeshPotential:
 
 
 # Test correct filling of zero and empty blocks when setting global atomic numbers
-def test_all_atomic_numbers():
-    all_atomic_numbers = [9, 1, 8]
-    descriptor = meshlode_metatensor(
-        atomic_smearing=1, all_atomic_numbers=all_atomic_numbers
+def test_all_atomic_types():
+    all_atomic_types = [9, 1, 8]
+    descriptor = meshlode_metatensor.MeshPotential(
+        atomic_smearing=1, all_atomic_types=all_atomic_types
     )
     values = descriptor.compute(toy_system_single_frame())
 
-    for n in all_atomic_numbers:
+    for n in all_atomic_types:
         assert len(values.block({"center_type": 9, "neighbor_type": n}).values) == 0
 
     for n in [1, 8]:


### PR DESCRIPTION
To be compatible with `torch_spex` this PR adds a new parameter `all_atomic_numbers` to set a global list of elements at initialization. If this is not set we use the "old" behavior and obtain the elements from the given systems.

One question is how we want to name it. I followed the internal logic and named the parameter `all_atomic_numbers` even though in torch_spex it is called `all_species`.

I also did some minor docs layout work.

<!-- readthedocs-preview meshlode start -->
----
📚 Documentation preview 📚: https://meshlode--10.org.readthedocs.build/en/10/

<!-- readthedocs-preview meshlode end -->