### PR TITLE
Disable Windows and macOS tests to reduce CI costs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         include:
+          # - os: ubuntu-22.04
+          #  python-version: "3.9"
           - os: ubuntu-22.04
-            python-version: "3.9"
-          - os: ubuntu-22.04
             python-version: "3.12"
-          - os: macos-14
-            python-version: "3.12"
-          - os: windows-2022
-            python-version: "3.12"
+          # - os: macos-14
+          #  python-version: "3.12"
+          # - os: windows-2022
+          #  python-version: "3.12"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Once "we" recharged the account these changes will reduce the costs of our CI by 75%