### PR TITLE
Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,10 +42,11 @@ jobs:
               mv ../docs/build/html latest
           fi
 
-      - name: deploy to gh-pages
-        if: github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./gh-pages/
-          force_orphan: true
+      # TODO: enable once repo is public
+      # - name: deploy to gh-pages
+      #   if: github.event_name == 'push'
+      #   uses: peaceiris/actions-gh-pages@v4
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: ./gh-pages/
+      #     force_orphan: true


### PR DESCRIPTION
As discussed with @kvhuguenin might be useful to disable the docs deployment while the repo is still private.

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--39.org.readthedocs.build/en/39/

<!-- readthedocs-preview torch-pme end -->