### PR TITLE
Make `_validate_compute_parameters` static methods

### DIFF
--- a/src/torchpme/calculators/base.py
+++ b/src/torchpme/calculators/base.py
@@ -14,8 +14,8 @@ class CalculatorBaseTorch(torch.nn.Module):
         self._device = torch.device("cpu")
         self._dtype = torch.float32
 
+    @staticmethod
     def _validate_compute_parameters(
-        self,
         positions: Union[List[torch.Tensor], torch.Tensor],
         charges: Union[List[torch.Tensor], torch.Tensor],
         cell: Union[List[Optional[torch.Tensor]], Optional[torch.Tensor]],
@@ -67,10 +67,8 @@ class CalculatorBaseTorch(torch.nn.Module):
         if not isinstance(neighbor_shifts, list):
             neighbor_shifts = [neighbor_shifts]
 
-        # In actual computations, the data type (dtype) and device (e.g. CPU, GPU) of
-        # all remaining variables need to be consistent
-        self._device = positions[0].device
-        self._dtype = positions[0].dtype
+        device = positions[0].device
+        dtype = positions[0].dtype
 
         # check charges
         if len(positions) != len(charges):
@@ -125,16 +123,16 @@ class CalculatorBaseTorch(torch.nn.Module):
                     f"least one tensor with shape {list(positions_single.shape)}"
                 )
 
-            if positions_single.dtype != self._dtype:
+            if positions_single.dtype != dtype:
                 raise ValueError(
-                    f"each `positions` must have the same type {self._dtype} as the "
+                    f"each `positions` must have the same type {dtype} as the "
                     "first provided one. Got at least one tensor of type "
                     f"{positions_single.dtype}"
                 )
 
-            if positions_single.device != self._device:
+            if positions_single.device != device:
                 raise ValueError(
-                    f"each `positions` must be on the same device {self._device} as "
+                    f"each `positions` must be on the same device {device} as "
                     "the first provided one. Got at least one tensor on device "
                     f"{positions_single.device}"
                 )
@@ -147,16 +145,16 @@ class CalculatorBaseTorch(torch.nn.Module):
                         f"one tensor with shape {list(cell_single.shape)}"
                     )
 
-                if cell_single.dtype != self._dtype:
+                if cell_single.dtype != dtype:
                     raise ValueError(
-                        f"each `cell` must have the same type {self._dtype} as "
+                        f"each `cell` must have the same type {dtype} as "
                         "`positions`, got at least one tensor of type "
                         f"{cell_single.dtype}"
                     )
 
-                if cell_single.device != self._device:
+                if cell_single.device != device:
                     raise ValueError(
-                        f"each `cell` must be on the same device {self._device} as "
+                        f"each `cell` must be on the same device {device} as "
                         "`positions`, got at least one tensor with device "
                         f"{cell_single.device}"
                     )
@@ -180,16 +178,16 @@ class CalculatorBaseTorch(torch.nn.Module):
                     f"positions contains {len(positions_single)} atoms"
                 )
 
-            if charges_single.dtype != self._dtype:
+            if charges_single.dtype != dtype:
                 raise ValueError(
-                    f"each `charges` must have the same type {self._dtype} as "
+                    f"each `charges` must have the same type {dtype} as "
                     "`positions`, got at least one tensor of type "
                     f"{charges_single.dtype}"
                 )
 
-            if charges_single.device != self._device:
+            if charges_single.device != device:
                 raise ValueError(
-                    f"each `charges` must be on the same device {self._device} as "
+                    f"each `charges` must be on the same device {device} as "
                     f"`positions`, got at least one tensor with device "
                     f"{charges_single.device}"
                 )
@@ -203,10 +201,10 @@ class CalculatorBaseTorch(torch.nn.Module):
                         "structure"
                     )
 
-                if neighbor_indices_single.device != self._device:
+                if neighbor_indices_single.device != device:
                     raise ValueError(
                         f"each `neighbor_indices` must be on the same device "
-                        f"{self._device} as `positions`, got at least one tensor with "
+                        f"{device} as `positions`, got at least one tensor with "
                         f"device {neighbor_indices_single.device}"
                     )
 
@@ -221,10 +219,10 @@ class CalculatorBaseTorch(torch.nn.Module):
                         "structure"
                     )
 
-                if neighbor_shifts_single.device != self._device:
+                if neighbor_shifts_single.device != device:
                     raise ValueError(
                         f"each `neighbor_shifts` must be on the same device "
-                        f"{self._device} as `positions`, got at least one tensor with "
+                        f"{device} as `positions`, got at least one tensor with "
                         f"device {neighbor_shifts_single.device}"
                     )
 
@@ -271,6 +269,11 @@ class CalculatorBaseTorch(torch.nn.Module):
             neighbor_indices=neighbor_indices,
             neighbor_shifts=neighbor_shifts,
         )
+
+        # In actual computations, the data type (dtype) and device (e.g. CPU, GPU) of
+        # all remaining variables need to be consistent
+        self._device = positions[0].device
+        self._dtype = positions[0].dtype
 
         # compute and append into a list the features of each structure
         potentials = []

--- a/src/torchpme/metatensor/base.py
+++ b/src/torchpme/metatensor/base.py
@@ -32,8 +32,8 @@ class CalculatorBaseMetatensor(torch.nn.Module):
         """Forward just calls :py:meth:`compute`."""
         return self.compute(systems, neighbors)
 
+    @staticmethod
     def _validate_compute_parameters(
-        self,
         systems: Union[List[System], System],
         neighbors: Union[List[Optional[TensorBlock]], Optional[TensorBlock]],
     ) -> Tuple[List[System], List[Optional[TensorBlock]]]:
@@ -70,41 +70,41 @@ class CalculatorBaseMetatensor(torch.nn.Module):
                 f"neighbors ({len(neighbors)})"
             )
 
-        self._dtype = systems[0].positions.dtype
-        self._device = systems[0].positions.device
+        dtype = systems[0].positions.dtype
+        device = systems[0].positions.device
 
         _components_labels = Labels(
             ["xyz"],
-            torch.arange(3, dtype=torch.int32, device=self._device).unsqueeze(1),
+            torch.arange(3, dtype=torch.int32, device=device).unsqueeze(1),
         )
         _properties_labels = Labels(
-            ["distance"], torch.zeros(1, 1, dtype=torch.int32, device=self._device)
+            ["distance"], torch.zeros(1, 1, dtype=torch.int32, device=device)
         )
 
         for system, neighbors_single in zip(systems, neighbors):
-            if system.positions.dtype != self._dtype:
+            if system.positions.dtype != dtype:
                 raise ValueError(
                     "`dtype` of all systems must be the same, got "
-                    f"{system.positions.dtype} and {self._dtype}`"
+                    f"{system.positions.dtype} and {dtype}`"
                 )
 
-            if system.positions.device != self._device:
+            if system.positions.device != device:
                 raise ValueError(
                     "`device` of all systems must be the same, got "
-                    f"{system.positions.device} and {self._device}`"
+                    f"{system.positions.device} and {device}`"
                 )
 
             if neighbors_single is not None:
-                if neighbors_single.values.dtype != self._dtype:
+                if neighbors_single.values.dtype != dtype:
                     raise ValueError(
-                        f"each `neighbors` must have the same type {self._dtype} "
+                        f"each `neighbors` must have the same type {dtype} "
                         "as `systems`, got at least one `neighbors` of type "
                         f"{neighbors_single.values.dtype}"
                     )
 
-                if neighbors_single.values.device != self._device:
+                if neighbors_single.values.device != device:
                     raise ValueError(
-                        f"each `neighbors` must be on the same device {self._device} "
+                        f"each `neighbors` must be on the same device {device} "
                         "as `systems`, got at least one `neighbors` with device "
                         f"{neighbors_single.values.device}"
                     )
@@ -144,15 +144,15 @@ class CalculatorBaseMetatensor(torch.nn.Module):
 
         # Metatensor will issue a warning because `charges` are not a default member of
         # a System object
-        self._n_charges_channels = systems[0].get_data("charges").values.shape[1]
+        n_charges_channels = systems[0].get_data("charges").values.shape[1]
 
         for i_system, system in enumerate(systems):
             n_channels = system.get_data("charges").values.shape[1]
-            if n_channels != self._n_charges_channels:
+            if n_channels != n_charges_channels:
                 raise ValueError(
                     f"number of charges-channels in system index {i_system} "
                     f"({n_channels}) is inconsistent with first system "
-                    f"({self._n_charges_channels})"
+                    f"({n_charges_channels})"
                 )
 
         return systems, neighbors
@@ -185,6 +185,13 @@ class CalculatorBaseMetatensor(torch.nn.Module):
         :return: TensorMap containing the potential of all types.
         """
         systems, neighbors = self._validate_compute_parameters(systems, neighbors)
+
+        # In actual computations, the data type (dtype) and device (e.g. CPU, GPU) of
+        # all remaining variables need to be consistent
+        self._dtype = systems[0].positions.dtype
+        self._device = systems[0].positions.device
+        self._n_charges_channels = systems[0].get_data("charges").values.shape[1]
+
         potentials: List[torch.Tensor] = []
         samples_list: List[torch.Tensor] = []
 


### PR DESCRIPTION
This is preparation for #44, where users will pass a system already at the init level. We should validate these inputs but can't use normal methods at this stage. This PR makes the `_validate_compute_parameters` static methods which required to factor out the setters of the `device`, the `dtype` and the `n_charges_channels` (metatensor only).

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--49.org.readthedocs.build/en/49/

<!-- readthedocs-preview torch-pme end -->