### PR TITLE
Tune `test_random_structure` parametrize

### DIFF
--- a/tests/calculators/test_values_ewald.py
+++ b/tests/calculators/test_values_ewald.py
@@ -16,32 +16,36 @@ DTYPE = torch.float64
 
 
 def generate_orthogonal_transformations():
+    # Generate rotation matrix along x-axis
+    def rot_x(phi):
+        rot = torch.zeros((3, 3), dtype=DTYPE)
+        rot[0, 0] = rot[1, 1] = math.cos(phi)
+        rot[0, 1] = -math.sin(phi)
+        rot[1, 0] = math.sin(phi)
+        rot[2, 2] = 1.0
 
-    # first rotation matrix: rotation by angle phi around z-axis
-    phi = 0.82321
-    rot_1 = torch.zeros((3, 3), dtype=DTYPE)
-    rot_1[0, 0] = rot_1[1, 1] = math.cos(phi)
-    rot_1[0, 1] = -math.sin(phi)
-    rot_1[1, 0] = math.sin(phi)
-    rot_1[2, 2] = 1.0
+        return rot
 
-    # second rotation matrix: second matrix followed by rotation by angle theta around y
-    theta = 1.23456
-    rot_2 = torch.zeros((3, 3), dtype=DTYPE)
-    rot_2[0, 0] = rot_2[2, 2] = math.cos(theta)
-    rot_2[0, 2] = math.sin(theta)
-    rot_2[2, 0] = -math.sin(theta)
-    rot_2[1, 1] = 1.0
-    rot_2 = rot_2 @ rot_1
+    # Generate rotation matrix along z-axis
+    def rot_z(theta):
+        rot = torch.zeros((3, 3), dtype=DTYPE)
+        rot[0, 0] = rot[2, 2] = math.cos(theta)
+        rot[0, 2] = math.sin(theta)
+        rot[2, 0] = -math.sin(theta)
+        rot[1, 1] = 1.0
 
-    # add additional orthogonal transformations by combining inversion
+        return rot
+
+    # Generate a few rotation matrices
+    rot_1 = rot_z(0.987654)
+    rot_2 = rot_z(1.23456) @ rot_x(0.82321)
     transformations = [rot_1, rot_2]
 
     # make sure that the generated transformations are indeed orthogonal
     for q in transformations:
         id = torch.eye(3, dtype=DTYPE)
         id_2 = q.T @ q
-        torch.testing.assert_close(id, id_2, atol=2e-15, rtol=1e-14)
+        torch.testing.assert_close(id, id_2, atol=1e-15, rtol=1e-15)
 
     return transformations
 
@@ -432,7 +436,7 @@ def test_random_structure(sr_cutoff, frame_index, scaling_factor, ortho, calc_na
     cell = scaling_factor * torch.tensor(np.array(frame.cell), dtype=DTYPE) @ ortho
     charges = torch.tensor([1, 1, 1, 1, -1, -1, -1, -1], dtype=DTYPE).reshape((-1, 1))
     sr_cutoff = scaling_factor * sr_cutoff
-    atomic_smearing = sr_cutoff / 5.0
+    atomic_smearing = sr_cutoff / 6.0
 
     # Compute neighbor list
     neighbor_indices, neighbor_shifts = neighbor_list_torch(
@@ -446,11 +450,11 @@ def test_random_structure(sr_cutoff, frame_index, scaling_factor, ortho, calc_na
     if calc_name == "ewald":
         calc = EwaldPotential(atomic_smearing=atomic_smearing)
         rtol_e = 2e-5
-        rtol_f = 3.6e-3
+        rtol_f = 3.5e-3
     elif calc_name == "pme":
         calc = PMEPotential(atomic_smearing=atomic_smearing)
-        rtol_e = 4.5e-3  # 1.5e-3
-        rtol_f = 2.5e-3  # 6e-3
+        rtol_e = 4.5e-3
+        rtol_f = 3.5e-3
 
     potentials = calc.compute(
         positions=positions,


### PR DESCRIPTION
I slightly changed the `test_random_structure` parametrization to be less extreme, resulting in faster evaluation. I brought down the timing from abou 7s per test to below 1s per test.

I think havin less a less extreme parametrize is okay since we have very good tests for the energy using the Madelung constants of crystals, and the `test_random_structure` is primarily for checking the forces.

Below are the slowest 20 tests on my Apple M2 machine which I got by running

```bash
tox -e tests -- --durations=20
```

<details>
<summary>Before</summary>

7.10s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-2.035361-2-2.01]  
7.10s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-0.4325-2-2.01]  
7.03s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-2.035361-0-2.01]  
7.01s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-2.035361-1-2.01]  
6.99s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-2.035361-0-2.01]  
6.97s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-2.035361-2-2.01]  
6.95s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-0.4325-2-2.01]  
6.95s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-0.4325-1-2.01]  
6.95s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-0.4325-0-2.01]  
6.93s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-0.4325-1-2.01]  
6.90s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-0.4325-0-2.01]  
6.85s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-2.035361-1-2.01]  
0.84s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-0.4325-2-5.5]  
0.83s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-2.035361-2-5.5]  
0.81s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-0.4325-2-5.5]  
0.81s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-2.035361-2-5.5]  
0.35s call     tests/calculators/test_base.py::test_invalid_device_positions  
0.23s call     tests/calculators/test_values_ewald.py::test_wigner[0.4325-wigner_fcc_cubiccell]  
0.23s call     tests/calculators/test_values_ewald.py::test_wigner[2.035361-wigner_fcc_cubiccell]  
0.23s call     tests/calculators/test_values_ewald.py::test_wigner[1.0-wigner_fcc_cubiccell]

</details>

<details>
<summary>After</summary>

0.82s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-0.4325-2-5.54]  
0.80s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-1.335361-2-5.54]  
0.80s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-1.335361-2-5.54]  
0.80s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-0.4325-2-5.54]  
0.80s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-0.4325-2-6.01]  
0.79s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-1.335361-2-6.01]  
0.79s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-1.335361-2-6.01]  
0.79s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-0.4325-2-6.01]  
0.41s call     tests/calculators/test_base.py::test_invalid_device_positions  
0.23s call     tests/calculators/test_values_ewald.py::test_wigner[0.4325-wigner_fcc_cubiccell]  
0.23s call     tests/calculators/test_values_ewald.py::test_wigner[2.035361-wigner_fcc_cubiccell]  
0.22s call     tests/calculators/test_values_ewald.py::test_wigner[1.0-wigner_fcc_cubiccell]  
0.13s call     tests/calculators/test_workflow.py::TestWorkflow::test_operation_as_torch_script[device0-PMEPotential-params2-True]  
0.10s call     tests/metatensor/test_workflow_metatensor.py::TestWorkflow::test_operation_as_torch_script[device0-PMEPotential-params2]  
0.09s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-1.335361-0-5.54]  
0.09s call     tests/calculators/test_values_ewald.py::test_wigner[1.0-wigner_bcc_cubiccell]  
0.09s call     tests/calculators/test_values_ewald.py::test_wigner[0.4325-wigner_bcc_cubiccell]  
0.09s call     tests/calculators/test_values_ewald.py::test_wigner[2.035361-wigner_bcc_cubiccell]  
0.08s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho0-0.4325-0-5.54]  
0.08s call     tests/calculators/test_values_ewald.py::test_random_structure[pme-ortho1-1.335361-0-5.54]

</details>


<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--51.org.readthedocs.build/en/51/

<!-- readthedocs-preview torch-pme end -->