### PR TITLE
Cleaner internal class design & remove `compute` method

### DIFF
--- a/docs/src/references/calculators/directpotential.rst
+++ b/docs/src/references/calculators/directpotential.rst
@@ -2,5 +2,5 @@ DirectPotential
 ###############
 
 .. autoclass:: torchpme.DirectPotential
-    :members:
+    :members: forward
     :undoc-members:

--- a/docs/src/references/calculators/ewaldpotential.rst
+++ b/docs/src/references/calculators/ewaldpotential.rst
@@ -2,5 +2,5 @@ EwaldPotential
 ##############
 
 .. autoclass:: torchpme.EwaldPotential
-    :members:
+    :members: forward
     :undoc-members:

--- a/docs/src/references/calculators/pmepotential.rst
+++ b/docs/src/references/calculators/pmepotential.rst
@@ -2,5 +2,5 @@ PMEPotential
 ############
 
 .. autoclass:: torchpme.PMEPotential
-    :members:
+    :members: forward
     :undoc-members:

--- a/docs/src/references/metatensor/directpotential.rst
+++ b/docs/src/references/metatensor/directpotential.rst
@@ -2,5 +2,5 @@ DirectPotential
 ###############
 
 .. autoclass:: torchpme.metatensor.DirectPotential
-    :members: compute, forward
+    :members: forward
     :undoc-members:

--- a/docs/src/references/metatensor/ewaldpotential.rst
+++ b/docs/src/references/metatensor/ewaldpotential.rst
@@ -2,5 +2,5 @@ EwaldPotential
 ##############
 
 .. autoclass:: torchpme.metatensor.EwaldPotential
-    :members: compute, forward
+    :members: forward
     :undoc-members:

--- a/docs/src/references/metatensor/pmepotential.rst
+++ b/docs/src/references/metatensor/pmepotential.rst
@@ -2,5 +2,5 @@ PMEPotential
 ############
 
 .. autoclass:: torchpme.metatensor.PMEPotential
-    :members: compute, forward
+    :members: forward
     :undoc-members:

--- a/examples/1-charges-example.py
+++ b/examples/1-charges-example.py
@@ -213,7 +213,7 @@ system.add_data(name="charges", data=data)
 # %%
 # We now calculate the potential using the MetaPMEPotential calculator
 
-potential_metatensor = calculator_metatensor.compute(system, neighbors)
+potential_metatensor = calculator_metatensor.forward(system, neighbors)
 
 # %%
 # The calculated potential is wrapped inside a :py:class:`TensorMap
@@ -258,7 +258,7 @@ system.add_data(name="charges", data=data_one_hot, override=True)
 
 # %%
 # Finally, we calculate the potential using ``calculator_metatensor``
-potential = calculator_metatensor.compute(system, neighbors)
+potential = calculator_metatensor.forward(system, neighbors)
 
 # %%
 # And as above, the values of the potential are the same.

--- a/examples/2-neighbor-lists-usage.py
+++ b/examples/2-neighbor-lists-usage.py
@@ -158,7 +158,7 @@ neighbor_distances = distances(
 # and initialize a PME instance to compute the potential.
 
 pme = PMEPotential()
-potential = pme.compute(
+potential = pme(
     positions=positions,
     charges=charges,
     cell=cell,
@@ -210,7 +210,7 @@ neighbor_indices_new = torch.stack([i, j], dim=1)
 #
 # Following the same steps as above, we compute the forces.
 
-potential_new = pme.compute(
+potential_new = pme(
     positions=positions_new,
     charges=charges,
     cell=cell,

--- a/src/torchpme/calculators/ewaldpotential.py
+++ b/src/torchpme/calculators/ewaldpotential.py
@@ -1,27 +1,63 @@
-from typing import List, Optional, Union
+from typing import Optional
 
 import torch
 
 from ..lib import generate_kvectors_for_ewald
 from ..lib.potentials import gamma
-from .base import CalculatorBaseTorch, PeriodicBase
+from .base import CalculatorBaseTorch
 
 
-class _EwaldPotentialImpl(PeriodicBase):
+class EwaldPotential(CalculatorBaseTorch):
+    r"""Potential computed using the Ewald sum.
+
+    Scaling as :math:`\mathcal{O}(N^2)` with respect to the number of particles
+    :math:`N`.
+
+    For computing a **neighborlist** a reasonable ``cutoff`` is half the length of
+    the shortest cell vector, which can be for example computed according as
+
+    .. code-block:: python
+
+        cell_dimensions = torch.linalg.norm(cell, dim=1)
+        cutoff = torch.min(cell_dimensions) / 2 - 1e-6
+
+    This ensures a accuracy of the short range part of ``1e-5``.
+
+    :param exponent: the exponent :math:`p` in :math:`1/r^p` potentials
+    :param atomic_smearing: Width of the atom-centered Gaussian used to split the
+        Coulomb potential into the short- and long-range parts. A reasonable value for
+        most systems is to set it to ``1/5`` times the neighbor list cutoff. If
+        :py:obj:`None` ,it will be set to 1/5 times of half the largest box vector
+        (separately for each structure).
+    :param lr_wavelength: Spatial resolution used for the long-range (reciprocal space)
+        part of the Ewald sum. More conretely, all Fourier space vectors with a
+        wavelength >= this value will be kept. If not set to a global value, it will be
+        set to half the atomic_smearing parameter to ensure convergence of the
+        long-range part to a relative precision of 1e-5.
+    :param subtract_interior: If set to :py:obj:`True`, subtract from the features of an
+        atom the contributions to the potential arising from all atoms within the cutoff
+        Note that if set to true, the self contribution (see previous) is also
+        subtracted by default.
+
+    For an **example** on the usage refer to :py:class:`PMEPotential`.
+    """
+
     def __init__(
         self,
-        exponent: float,
-        atomic_smearing: Optional[float],
-        lr_wavelength: Optional[float],
-        subtract_interior: bool,
+        exponent: float = 1.0,
+        atomic_smearing: Optional[float] = None,
+        lr_wavelength: Optional[float] = None,
+        subtract_interior: bool = False,
     ):
-        PeriodicBase.__init__(
-            self,
-            exponent=exponent,
-            atomic_smearing=atomic_smearing,
-            subtract_interior=subtract_interior,
-        )
+        super().__init__(exponent=exponent)
+
         self.lr_wavelength = lr_wavelength
+        self.subtract_interior = subtract_interior
+
+        if atomic_smearing is not None and atomic_smearing <= 0:
+            raise ValueError(f"`atomic_smearing` {atomic_smearing} has to be positive")
+        else:
+            self.atomic_smearing = atomic_smearing
 
     def _compute_single_system(
         self,
@@ -40,7 +76,10 @@ class _EwaldPotentialImpl(PeriodicBase):
         # convergence of the SR and LR sums, respectively. The default values are
         # chosen to reach a convergence on the order of 1e-4 to 1e-5 for the test
         # structures.
-        smearing = self._estimate_smearing(cell)
+        if self.atomic_smearing is None:
+            smearing = self.estimate_smearing(cell)
+        else:
+            smearing = self.atomic_smearing
 
         if self.lr_wavelength is None:
             lr_wavelength = 0.5 * smearing
@@ -49,10 +88,12 @@ class _EwaldPotentialImpl(PeriodicBase):
 
         # Compute short-range (SR) part using a real space sum
         potential_sr = self._compute_sr(
+            is_periodic=True,
             smearing=smearing,
             charges=charges,
             neighbor_indices=neighbor_indices,
             neighbor_distances=neighbor_distances,
+            subtract_interior=self.subtract_interior,
         )
 
         # Compute long-range (LR) part using a Fourier / reciprocal space sum
@@ -151,127 +192,3 @@ class _EwaldPotentialImpl(PeriodicBase):
 
         # Compensate for double counting of pairs (i,j) and (j,i)
         return energy / 2
-
-
-class EwaldPotential(CalculatorBaseTorch, _EwaldPotentialImpl):
-    r"""Potential computed using the Ewald sum.
-
-    Scaling as :math:`\mathcal{O}(N^2)` with respect to the number of particles
-    :math:`N`.
-
-    For computing a **neighborlist** a reasonable ``cutoff`` is half the length of
-    the shortest cell vector, which can be for example computed according as
-
-    .. code-block:: python
-
-        cell_dimensions = torch.linalg.norm(cell, dim=1)
-        cutoff = torch.min(cell_dimensions) / 2 - 1e-6
-
-    This ensures a accuracy of the short range part of ``1e-5``.
-
-    :param exponent: the exponent :math:`p` in :math:`1/r^p` potentials
-    :param atomic_smearing: Width of the atom-centered Gaussian used to split the
-        Coulomb potential into the short- and long-range parts. A reasonable value for
-        most systems is to set it to ``1/5`` times the neighbor list cutoff. If
-        :py:obj:`None` ,it will be set to 1/5 times of half the largest box vector
-        (separately for each structure).
-    :param lr_wavelength: Spatial resolution used for the long-range (reciprocal space)
-        part of the Ewald sum. More conretely, all Fourier space vectors with a
-        wavelength >= this value will be kept. If not set to a global value, it will be
-        set to half the atomic_smearing parameter to ensure convergence of the
-        long-range part to a relative precision of 1e-5.
-    :param subtract_interior: If set to :py:obj:`True`, subtract from the features of an
-        atom the contributions to the potential arising from all atoms within the cutoff
-        Note that if set to true, the self contribution (see previous) is also
-        subtracted by default.
-
-    For an **example** on the usage refer to :py:class:`PMEPotential`.
-    """
-
-    def __init__(
-        self,
-        exponent: float = 1.0,
-        atomic_smearing: Optional[float] = None,
-        lr_wavelength: Optional[float] = None,
-        subtract_interior: bool = False,
-    ):
-        _EwaldPotentialImpl.__init__(
-            self,
-            exponent=exponent,
-            atomic_smearing=atomic_smearing,
-            lr_wavelength=lr_wavelength,
-            subtract_interior=subtract_interior,
-        )
-        CalculatorBaseTorch.__init__(self)
-
-    def compute(
-        self,
-        positions: Union[List[torch.Tensor], torch.Tensor],
-        charges: Union[List[torch.Tensor], torch.Tensor],
-        cell: Union[List[torch.Tensor], torch.Tensor],
-        neighbor_indices: Union[List[torch.Tensor], torch.Tensor],
-        neighbor_distances: Union[List[torch.Tensor], torch.Tensor],
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        """Compute potential for all provided "systems" stacked inside list.
-
-        The computation is performed on the same ``device`` as ``dtype`` is the input is
-        stored on. The ``dtype`` of the output tensors will be the same as the input.
-
-        For computing a **neighborlist** a reasonable ``cutoff`` is half the length of
-        the shortest cell vector, which can be for example computed according as
-
-        .. code-block:: python
-
-            cell_dimensions = torch.linalg.norm(cell, dim=1)
-            cutoff = torch.min(cell_dimensions) / 2 - 1e-6
-
-        :param positions: Single or 2D tensor of shape (``len(charges), 3``) containing
-            the Cartesian positions of all point charges in the system.
-        :param charges: Single 2D tensor or list of 2D tensor of shape (``n_channels,
-            len(positions))``. ``n_channels`` is the number of charge channels the
-            potential should be calculated for a standard potential ``n_channels=1``. If
-            more than one "channel" is provided multiple potentials for the same
-            position but different are computed.
-        :param cell: single or 2D tensor of shape (3, 3), describing the bounding
-            box/unit cell of the system. Each row should be one of the bounding box
-            vector; and columns should contain the x, y, and z components of these
-            vectors (i.e. the cell should be given in row-major order).
-        :param neighbor_indices: Single or list of 2D tensors of shape ``(n, 2)``, where
-            ``n`` is the number of neighbors. The two columns correspond to the indices
-            of a **half neighbor list** for the two atoms which are considered neighbors
-            (e.g. within a cutoff distance).
-        :param neighbor_distances: single or list of 1D tensors containing the distance
-            between the ``n`` pairs corresponding to a **half neighbor list**.
-        :return: Single or list of torch tensors containing the potential(s) for all
-            positions. Each tensor in the list is of shape ``(len(positions),
-            len(charges))``, where If the inputs are only single tensors only a single
-            torch tensor with the potentials is returned.
-        """
-
-        return self._compute_impl(
-            positions=positions,
-            charges=charges,
-            cell=cell,
-            neighbor_indices=neighbor_indices,
-            neighbor_distances=neighbor_distances,
-        )
-
-    # This function is kept to keep torch-pme compatible with the broader pytorch
-    # infrastructure, which require a "forward" function. We name this function
-    # "compute" instead, for compatibility with other COSMO software.
-    def forward(
-        self,
-        positions: Union[List[torch.Tensor], torch.Tensor],
-        charges: Union[List[torch.Tensor], torch.Tensor],
-        cell: Union[List[torch.Tensor], torch.Tensor],
-        neighbor_indices: Union[List[torch.Tensor], torch.Tensor],
-        neighbor_distances: Union[List[torch.Tensor], torch.Tensor],
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        """Forward just calls :py:meth:`compute`."""
-        return self.compute(
-            positions=positions,
-            charges=charges,
-            cell=cell,
-            neighbor_indices=neighbor_indices,
-            neighbor_distances=neighbor_distances,
-        )

--- a/src/torchpme/metatensor/base.py
+++ b/src/torchpme/metatensor/base.py
@@ -24,14 +24,6 @@ class CalculatorBaseMetatensor(torch.nn.Module):
         self._dtype = torch.float32
         self._n_charges_channels = 0
 
-    def forward(
-        self,
-        systems: Union[List[System], System],
-        neighbors: Union[List[TensorBlock], TensorBlock],
-    ) -> TensorMap:
-        """Forward just calls :py:meth:`compute`."""
-        return self.compute(systems, neighbors)
-
     @staticmethod
     def _validate_compute_parameters(
         systems: Union[List[System], System],
@@ -149,7 +141,7 @@ class CalculatorBaseMetatensor(torch.nn.Module):
 
         return systems, neighbors
 
-    def compute(
+    def forward(
         self,
         systems: Union[List[System], System],
         neighbors: Union[List[TensorBlock], TensorBlock],
@@ -211,9 +203,9 @@ class CalculatorBaseMetatensor(torch.nn.Module):
                 neighbors_single.values, dim=1
             ).squeeze(1)
 
-            # `_compute_single_system` is implemented only in child classes!
+            # `calculator._compute_single_system` is implemented only in child classes!
             potentials.append(
-                self._compute_single_system(
+                self.calculator._compute_single_system(
                     positions=system.positions,
                     charges=system.get_data("charges").values,
                     cell=system.cell,

--- a/src/torchpme/metatensor/directpotential.py
+++ b/src/torchpme/metatensor/directpotential.py
@@ -1,8 +1,8 @@
-from ..calculators.directpotential import _DirectPotentialImpl
+from ..calculators.directpotential import DirectPotential as DirectPotentialTorch
 from .base import CalculatorBaseMetatensor
 
 
-class DirectPotential(CalculatorBaseMetatensor, _DirectPotentialImpl):
+class DirectPotential(CalculatorBaseMetatensor):
     r"""Potential using a direct summation.
 
     Refer to :class:`torchpme.DirectPotential` for parameter documentation.
@@ -79,7 +79,7 @@ class DirectPotential(CalculatorBaseMetatensor, _DirectPotentialImpl):
     :py:class:`torchpme.metatensor.PMEPotential` for details on the process.
 
     >>> direct = DirectPotential()
-    >>> potential = direct.compute(system, neighbors)
+    >>> potential = direct.forward(system, neighbors)
 
     The results are stored inside the ``values`` property inside the first
     :py:class:`TensorBlock <metatensor.torch.TensorBlock>` of the ``potential``.
@@ -93,5 +93,5 @@ class DirectPotential(CalculatorBaseMetatensor, _DirectPotentialImpl):
     """
 
     def __init__(self, exponent: float = 1.0):
-        _DirectPotentialImpl.__init__(self, exponent=exponent)
-        CalculatorBaseMetatensor.__init__(self)
+        super().__init__()
+        self.calculator = DirectPotentialTorch(exponent=exponent)

--- a/src/torchpme/metatensor/ewaldpotential.py
+++ b/src/torchpme/metatensor/ewaldpotential.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from ..calculators.ewaldpotential import _EwaldPotentialImpl
+from ..calculators.ewaldpotential import EwaldPotential as EwaldPotentialTorch
 from .base import CalculatorBaseMetatensor
 
 
-class EwaldPotential(CalculatorBaseMetatensor, _EwaldPotentialImpl):
+class EwaldPotential(CalculatorBaseMetatensor):
     r"""Potential computed using the Ewald sum.
 
     Refer to :class:`torchpme.EwaldPotential` for parameter documentation.
@@ -20,11 +20,10 @@ class EwaldPotential(CalculatorBaseMetatensor, _EwaldPotentialImpl):
         lr_wavelength: Optional[float] = None,
         subtract_interior: bool = False,
     ):
-        _EwaldPotentialImpl.__init__(
-            self,
+        super().__init__()
+        self.calculator = EwaldPotentialTorch(
             exponent=exponent,
             atomic_smearing=atomic_smearing,
             lr_wavelength=lr_wavelength,
             subtract_interior=subtract_interior,
         )
-        CalculatorBaseMetatensor.__init__(self)

--- a/src/torchpme/metatensor/pmepotential.py
+++ b/src/torchpme/metatensor/pmepotential.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from ..calculators.pmepotential import _PMEPotentialImpl
+from ..calculators.pmepotential import PMEPotential as PMEPotentialTorch
 from .base import CalculatorBaseMetatensor
 
 
-class PMEPotential(CalculatorBaseMetatensor, _PMEPotentialImpl):
+class PMEPotential(CalculatorBaseMetatensor):
     r"""Potential using a particle mesh-based Ewald (PME).
 
     Refer to :class:`torchpme.PMEPotential` for parameter documentation.
@@ -86,7 +86,7 @@ class PMEPotential(CalculatorBaseMetatensor, _PMEPotentialImpl):
     and ``compute`` the potential for the crystal
 
     >>> pme = PMEPotential()
-    >>> potential = pme.compute(systems=system, neighbors=neighbors)
+    >>> potential = pme.forward(systems=system, neighbors=neighbors)
 
     The results are stored inside the ``values`` property inside the first
     :py:class:`TensorBlock <metatensor.torch.TensorBlock>` of the ``potential``.
@@ -95,7 +95,7 @@ class PMEPotential(CalculatorBaseMetatensor, _PMEPotentialImpl):
     tensor([[-1.0192],
             [ 1.0192]], dtype=torch.float64)
 
-    Which is the same as the reference value given above.
+    Which is close to the reference value given above.
     """
 
     def __init__(
@@ -106,12 +106,11 @@ class PMEPotential(CalculatorBaseMetatensor, _PMEPotentialImpl):
         interpolation_order: int = 3,
         subtract_interior: bool = False,
     ):
-        _PMEPotentialImpl.__init__(
-            self,
+        super().__init__()
+        self.calculator = PMEPotentialTorch(
             exponent=exponent,
             atomic_smearing=atomic_smearing,
             mesh_spacing=mesh_spacing,
             interpolation_order=interpolation_order,
             subtract_interior=subtract_interior,
         )
-        CalculatorBaseMetatensor.__init__(self)

--- a/tests/calculators/test_values_direct.py
+++ b/tests/calculators/test_values_direct.py
@@ -172,9 +172,10 @@ def test_coulomb_exact(
         positions=positions, periodic=False, cutoff=scaling_factor * 10
     )
 
-    potentials = direct.compute(
+    potentials = direct.forward(
         positions,
         charges=charges,
+        cell=torch.eye(3, dtype=DTYPE),  # ignored in actual calculations
         neighbor_indices=neighbor_indices,
         neighbor_distances=neighbor_distances,
     )

--- a/tests/calculators/test_values_ewald.py
+++ b/tests/calculators/test_values_ewald.py
@@ -323,7 +323,7 @@ def test_madelung(crystal_name, scaling_factor, calc_name):
     )
 
     # Compute potential and compare against target value using default hypers
-    potentials = calc.compute(
+    potentials = calc.forward(
         positions=pos,
         charges=charges,
         cell=cell,
@@ -387,7 +387,7 @@ def test_wigner(crystal_name, scaling_factor):
 
         # Compute potential and compare against reference
         calc = EwaldPotential(atomic_smearing=smeareff)
-        potentials = calc.compute(
+        potentials = calc.forward(
             positions=positions,
             charges=charges,
             cell=cell,
@@ -455,7 +455,7 @@ def test_random_structure(sr_cutoff, frame_index, scaling_factor, ortho, calc_na
         rtol_e = 4.5e-3
         rtol_f = 3.5e-3
 
-    potentials = calc.compute(
+    potentials = calc.forward(
         positions=positions,
         charges=charges,
         cell=cell,

--- a/tests/calculators/test_workflow.py
+++ b/tests/calculators/test_workflow.py
@@ -23,16 +23,15 @@ INTERPOLATION_ORDER = 2
 
 
 @pytest.mark.parametrize(
-    "CalculatorClass, params, periodic",
+    "CalculatorClass, params",
     [
-        (DirectPotential, {}, False),
+        (DirectPotential, {}),
         (
             EwaldPotential,
             {
                 "atomic_smearing": ATOMIC_SMEARING,
                 "lr_wavelength": LR_WAVELENGTH,
             },
-            True,
         ),
         (
             PMEPotential,
@@ -41,67 +40,56 @@ INTERPOLATION_ORDER = 2
                 "mesh_spacing": MESH_SPACING,
                 "interpolation_order": INTERPOLATION_ORDER,
             },
-            True,
         ),
     ],
 )
 class TestWorkflow:
-    def cscl_system(self, periodic, device=None):
+    def cscl_system(self, device=None):
         """CsCl crystal. Same as in the madelung test"""
         if device is None:
             device = torch.device("cpu")
 
         positions = torch.tensor([[0, 0, 0], [0.5, 0.5, 0.5]])
         charges = torch.tensor([1.0, -1.0]).reshape((-1, 1))
+        cell = torch.eye(3)
         neighbor_indices = torch.tensor([[0, 1]], dtype=torch.int64)
         neighbor_distances = torch.tensor([0.8660])
-        if periodic:
-            cell = torch.eye(3)
 
-            return (
-                positions.to(device=device),
-                charges.to(device=device),
-                cell.to(device=device),
-                neighbor_indices.to(device=device),
-                neighbor_distances.to(device=device),
-            )
-        else:
-            return (
-                positions.to(device=device),
-                charges.to(device=device),
-                neighbor_indices.to(device=device),
-                neighbor_distances.to(device=device),
-            )
+        return (
+            positions.to(device=device),
+            charges.to(device=device),
+            cell.to(device=device),
+            neighbor_indices.to(device=device),
+            neighbor_distances.to(device=device),
+        )
 
-    def test_interpolation_order_error(self, CalculatorClass, params, periodic):
+    def test_interpolation_order_error(self, CalculatorClass, params):
         if type(CalculatorClass) in [PMEPotential]:
             match = "Only `interpolation_order` from 1 to 5"
             with pytest.raises(ValueError, match=match):
                 CalculatorClass(atomic_smearing=1, interpolation_order=10)
 
-    def test_multi_frame(self, CalculatorClass, params, periodic):
+    def test_atomic_smearing_non_positive(self, CalculatorClass, params):
+        if type(CalculatorClass) in [EwaldPotential, PMEPotential]:
+            match = r"`atomic_smearing` .* has to be positive"
+            with pytest.raises(ValueError, match=match):
+                CalculatorClass(atomic_smearing=0)
+            with pytest.raises(ValueError, match=match):
+                CalculatorClass(atomic_smearing=-0.1)
+
+    def test_multi_frame(self, CalculatorClass, params):
         calculator = CalculatorClass(**params)
-        if periodic:
-            positions, charges, cell, neighbor_indices, neighbor_distance = (
-                self.cscl_system(periodic)
-            )
-            l_values = calculator.compute(
-                positions=[positions, positions],
-                cell=[cell, cell],
-                charges=[charges, charges],
-                neighbor_indices=[neighbor_indices, neighbor_indices],
-                neighbor_distances=[neighbor_distance, neighbor_distance],
-            )
-        else:
-            positions, charges, neighbor_indices, neighbor_distance = self.cscl_system(
-                periodic
-            )
-            l_values = calculator.compute(
-                positions=[positions, positions],
-                charges=[charges, charges],
-                neighbor_indices=[neighbor_indices, neighbor_indices],
-                neighbor_distances=[neighbor_distance, neighbor_distance],
-            )
+        positions, charges, cell, neighbor_indices, neighbor_distance = (
+            self.cscl_system()
+        )
+
+        l_values = calculator.forward(
+            positions=[positions, positions],
+            cell=[cell, cell],
+            charges=[charges, charges],
+            neighbor_indices=[neighbor_indices, neighbor_indices],
+            neighbor_distances=[neighbor_distance, neighbor_distance],
+        )
 
         for values in l_values:
             assert_close(
@@ -111,60 +99,49 @@ class TestWorkflow:
                 rtol=1e-5,
             )
 
-    def test_dtype_device(self, CalculatorClass, params, periodic):
+    def test_dtype_device(self, CalculatorClass, params):
         """Test that the output dtype and device are the same as the input."""
         device = "cpu"
         dtype = torch.float64
 
         positions = torch.tensor([[0.0, 0.0, 0.0]], dtype=dtype, device=device)
         charges = torch.ones((1, 2), dtype=dtype, device=device)
+        cell = torch.eye(3, dtype=dtype, device=device)
         neighbor_indices = torch.tensor([[0, 0]], device=device)
         neighbor_distances = torch.tensor([0.1], device=device)
 
         calculator = CalculatorClass(**params)
-        if periodic:
-            cell = torch.eye(3, dtype=dtype, device=device)
-            potential = calculator.compute(
-                positions=positions,
-                charges=charges,
-                cell=cell,
-                neighbor_indices=neighbor_indices,
-                neighbor_distances=neighbor_distances,
-            )
-        else:
-            potential = calculator.compute(
-                positions=positions,
-                charges=charges,
-                neighbor_indices=neighbor_indices,
-                neighbor_distances=neighbor_distances,
-            )
+
+        potential = calculator.forward(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            neighbor_indices=neighbor_indices,
+            neighbor_distances=neighbor_distances,
+        )
 
         assert potential.dtype == dtype
         assert potential.device.type == device
 
-    def check_operation(self, calculator, periodic, device):
+    def check_operation(self, calculator, device):
         """Make sure computation runs and returns a torch.Tensor."""
-        descriptor_compute = calculator.compute(*self.cscl_system(periodic, device))
-        descriptor_forward = calculator.forward(*self.cscl_system(periodic, device))
-
-        assert type(descriptor_compute) is torch.Tensor
-        assert type(descriptor_forward) is torch.Tensor
-        assert torch.equal(descriptor_forward, descriptor_compute)
+        descriptor = calculator.forward(*self.cscl_system(device))
+        assert type(descriptor) is torch.Tensor
 
     @pytest.mark.parametrize("device", AVAILABLE_DEVICES)
-    def test_operation_as_python(self, CalculatorClass, params, periodic, device):
+    def test_operation_as_python(self, CalculatorClass, params, device):
         """Run `check_operation` as a normal python script"""
         calculator = CalculatorClass(**params)
-        self.check_operation(calculator=calculator, periodic=periodic, device=device)
+        self.check_operation(calculator=calculator, device=device)
 
     @pytest.mark.parametrize("device", AVAILABLE_DEVICES)
-    def test_operation_as_torch_script(self, CalculatorClass, params, periodic, device):
+    def test_operation_as_torch_script(self, CalculatorClass, params, device):
         """Run `check_operation` as a compiled torch script module."""
         calculator = CalculatorClass(**params)
         scripted = torch.jit.script(calculator)
-        self.check_operation(calculator=scripted, periodic=periodic, device=device)
+        self.check_operation(calculator=scripted, device=device)
 
-    def test_save_load(self, CalculatorClass, params, periodic):
+    def test_save_load(self, CalculatorClass, params):
         calculator = CalculatorClass(**params)
         scripted = torch.jit.script(calculator)
         with io.BytesIO() as buffer:

--- a/tests/metatensor/test_workflow_metatensor.py
+++ b/tests/metatensor/test_workflow_metatensor.py
@@ -87,16 +87,11 @@ class TestWorkflow:
     def check_operation(self, calculator, device):
         """Make sure computation runs and returns a metatensor.TensorMap."""
         system, neighbors = self.system(device)
-        descriptor_compute = calculator.compute(system, neighbors)
-        descriptor_forward = calculator.forward(system, neighbors)
+        descriptor = calculator.forward(system, neighbors)
 
-        assert isinstance(descriptor_compute, torch.ScriptObject)
-        assert isinstance(descriptor_forward, torch.ScriptObject)
+        assert isinstance(descriptor, torch.ScriptObject)
         if version.parse(torch.__version__) >= version.parse("2.1"):
-            assert descriptor_compute._type().name() == "TensorMap"
-            assert descriptor_forward._type().name() == "TensorMap"
-
-        assert mts_torch.equal(descriptor_forward, descriptor_compute)
+            assert descriptor._type().name() == "TensorMap"
 
     @pytest.mark.parametrize("device", AVAILABLE_DEVICES)
     def test_operation_as_python(self, CalculatorClass, params, device):


### PR DESCRIPTION
Fixes #50

Major cleanup of the calculator class design as it was critized a lot recently, The major changes are

- Remove private `_ImplXXX` classes -> Metatensor classes are now wrapper classes around the torch classes
- Remove `PeriodicBase` -> logic now lives inside `CalculatorBaseTorch`
- Remove `compute()` method -> see discussion in #50

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--53.org.readthedocs.build/en/53/

<!-- readthedocs-preview torch-pme end -->