### PR TITLE
Add abstract method for `_compute_single_system` in base class

### DIFF
--- a/docs/src/references/base.rst
+++ b/docs/src/references/base.rst
@@ -8,6 +8,7 @@ General Base classes all calculators build on top.
 .. automodule:: torchpme.calculators.base
     :members:
     :undoc-members:
+    :private-members: _compute_single_system
 
 .. automodule:: torchpme.metatensor.base
     :members:

--- a/src/torchpme/calculators/base.py
+++ b/src/torchpme/calculators/base.py
@@ -267,6 +267,22 @@ class CalculatorBaseTorch(torch.nn.Module):
 
         return positions, charges, cell, neighbor_indices, neighbor_distances
 
+    def _compute_single_system(
+        self,
+        positions: torch.Tensor,
+        charges: torch.Tensor,
+        cell: torch.Tensor,
+        neighbor_indices: torch.Tensor,
+        neighbor_distances: torch.Tensor,
+    ) -> torch.Tensor:
+        """Core method for calculations for an individual atomic structure.
+
+        The actual logic has to be implemented in each calculator. Each calculators'
+        main (user-facing) :py:meth:`forward` method then simply loops over all
+        structures to apply this function on each.
+        """
+        raise NotImplementedError("Only implemented in child classes!")
+
     def forward(
         self,
         positions: Union[List[torch.Tensor], torch.Tensor],
@@ -337,7 +353,6 @@ class CalculatorBaseTorch(torch.nn.Module):
             neighbor_indices_single,
             neighbor_distances_single,
         ) in zip(positions, charges, cell, neighbor_indices, neighbor_distances):
-            # `_compute_single_system` is implemented only in child classes!
             potentials.append(
                 self._compute_single_system(
                     positions=positions_single,


### PR DESCRIPTION
This change should make it easier to follow what is going on with the `_compute_single_system` method and where it actually lives.

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--55.org.readthedocs.build/en/55/

<!-- readthedocs-preview torch-pme end -->