### PR TITLE
Move to Ruff

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -5,13 +5,11 @@ from datetime import datetime
 
 import tomli
 
-
 # When importing metatensor-torch, this will change the definition of the classes
 # to include the documentation
 os.environ["METATENSOR_IMPORT_FOR_SPHINX"] = "1"
 
-import torchpme  # noqa: E402
-
+import torchpme  # noqa
 
 suppress_warnings = ["config.cache"]
 

--- a/examples/1-charges-example.py
+++ b/examples/1-charges-example.py
@@ -33,7 +33,6 @@ from metatensor.torch.atomistic import System
 
 import torchpme
 
-
 # %%
 # Define a global constant for the cutoff of the neighbor list calculations.
 cutoff = 1.0
@@ -78,7 +77,7 @@ charges = torch.tensor([[1.0], [-1.0]], dtype=torch.float64)
 # number of atoms (here ``(2)``) and the *columns* the number of atomic charge channels
 # (here ``(1)``).
 
-charges.shape
+print(charges.shape)
 
 # %%
 # Calculate the potential using the PMEPotential calculator

--- a/examples/2-neighbor-lists-usage.py
+++ b/examples/2-neighbor-lists-usage.py
@@ -45,7 +45,6 @@ import vesin.torch
 
 from torchpme import PMEPotential
 
-
 # %%
 #
 # The test system

--- a/examples/3-mesh-demo.py
+++ b/examples/3-mesh-demo.py
@@ -19,7 +19,6 @@ from matplotlib import pyplot as plt
 
 import torchpme
 
-
 device = "cpu"
 dtype = torch.float64
 rng = torch.Generator()

--- a/examples/4-kspace-demo.py
+++ b/examples/4-kspace-demo.py
@@ -24,7 +24,6 @@ from matplotlib import pyplot as plt
 
 import torchpme
 
-
 device = "cpu"
 dtype = torch.float64
 
@@ -58,7 +57,6 @@ mesh_value = (
 # This is the filter function. NB it is applied
 # to the *squared k vector norm*
 class GaussianSmearingKernel(torchpme.lib.KSpaceKernel):
-
     def __init__(self, sigma2: float):
         self._sigma2 = sigma2
 
@@ -202,9 +200,7 @@ class MultiKernel(torchpme.lib.KSpaceKernel):
         self._sigma = sigma
 
     def from_k_sq(self, k2):
-
-        filter = torch.stack([torch.exp(-k2 * s**2 / 2) for s in self._sigma])
-        return filter
+        return torch.stack([torch.exp(-k2 * s**2 / 2) for s in self._sigma])
 
 
 # %%

--- a/examples/5-autograd-demo.py
+++ b/examples/5-autograd-demo.py
@@ -23,7 +23,6 @@ import torch
 
 import torchpme
 
-
 device = "cpu"
 dtype = torch.float64
 rng = torch.Generator()
@@ -198,7 +197,6 @@ class ParametricKernel(torch.nn.Module):
         self._a0 = a0
 
     def from_k_sq(self, k2):
-
         filter = torch.stack([torch.exp(-k2 * s**2 / 2) for s in self._sigma])
         filter[0, :] *= self._a0[0] / (1 + k2)
         filter[1, :] *= self._a0[1] / (1 + k2**3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,7 @@ keywords = [
     "TorchScript",
     "Scientific Computing",
 ]
-dependencies = [
-    "torch >=2.3",
-]
+dependencies = ["torch >=2.3"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
@@ -57,9 +55,7 @@ examples = [
     "vesin >= 0.2.0",
     "vesin-torch >= 0.2.0",
 ]
-metatensor = [
-    "metatensor-torch <0.6,>=0.5",
-]
+metatensor = ["metatensor-torch <0.6,>=0.5"]
 
 [project.urls]
 homepage = "http://torch-pme.readthedocs.io"
@@ -69,9 +65,7 @@ issues = "https://github.com/lab-cosmo/torch-pme/issues"
 
 [tool.coverage.report]
 show_missing = true
-include = [
-    "src/torchpme/*"
-]
+include = ["src/torchpme/*"]
 
 [tool.coverage.run]
 branch = true
@@ -80,22 +74,25 @@ data_file = 'tests/.coverage'
 [tool.coverage.xml]
 output = 'tests/coverage.xml'
 
-[tool.black]
-exclude = 'docs/src/examples'
+[tool.ruff]
+exclude = ["docs/src/examples/**"]
+line-length = 88
 
-[tool.isort]
-skip = "__init__.py"
-profile = "black"
-line_length = 88
-indent = 4
-include_trailing_comma = true
-lines_after_imports = 2
-known_first_party = "torchpme"
+[tool.ruff.lint]
+# See https://docs.astral.sh/ruff/rules for details
+extend-select = ["B", "E", "UP", "I", "SIM", "PT", "RET", "W", "Q"]
+
+# E501: don't worry about too long lines
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["torchpme"]
+
+[tool.ruff.format]
+docstring-code-format = true
 
 [tool.mypy]
-exclude = [
-    "docs/src/examples"
-]
+exclude = ["docs/src/examples"]
 follow_imports = 'skip'
 ignore_missing_imports = true
 

--- a/src/torchpme/__init__.py
+++ b/src/torchpme/__init__.py
@@ -1,11 +1,11 @@
-from .calculators.ewaldpotential import EwaldPotential
+import contextlib
+
 from .calculators.directpotential import DirectPotential
+from .calculators.ewaldpotential import EwaldPotential
 from .calculators.pmepotential import PMEPotential
 
-try:
+with contextlib.suppress(ImportError):
     from . import metatensor  # noqa
-except ImportError:
-    pass
 
 
 __all__ = ["EwaldPotential", "DirectPotential", "PMEPotential"]

--- a/src/torchpme/calculators/__init__.py
+++ b/src/torchpme/calculators/__init__.py
@@ -1,5 +1,5 @@
-from .ewaldpotential import EwaldPotential
 from .directpotential import DirectPotential
+from .ewaldpotential import EwaldPotential
 from .pmepotential import PMEPotential
 
 __all__ = ["EwaldPotential", "DirectPotential", "PMEPotential"]

--- a/src/torchpme/calculators/base.py
+++ b/src/torchpme/calculators/base.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union
+from typing import Union
 
 import torch
 
@@ -6,7 +6,8 @@ from ..lib import InversePowerLawPotential
 
 
 class CalculatorBaseTorch(torch.nn.Module):
-    """Base calculator for the torch interface.
+    """
+    Base calculator for the torch interface.
 
     :param exponent: the exponent :math:`p` in :math:`1/r^p` potentials
     :param smearing: smearing parameter of a range separated potential
@@ -25,11 +26,8 @@ class CalculatorBaseTorch(torch.nn.Module):
 
         if exponent < 0.0 or exponent > 3.0:
             raise ValueError(f"`exponent` p={exponent} has to satisfy 0 < p <= 3")
-        else:
-            self.exponent = exponent
-            self.potential = InversePowerLawPotential(
-                exponent=exponent, smearing=smearing
-            )
+        self.exponent = exponent
+        self.potential = InversePowerLawPotential(exponent=exponent, smearing=smearing)
 
         self.full_neighbor_list = full_neighbor_list
 
@@ -41,7 +39,6 @@ class CalculatorBaseTorch(torch.nn.Module):
         neighbor_distances: torch.Tensor,
         subtract_interior: bool,
     ) -> torch.Tensor:
-
         if is_periodic:
             # If the contribution from all atoms within the cutoff is to be subtracted
             # this short-range part will simply use -V_LR as the potential
@@ -75,7 +72,8 @@ class CalculatorBaseTorch(torch.nn.Module):
     def estimate_smearing(
         cell: torch.Tensor,
     ) -> float:
-        """Estimate the smearing for ewald calculators.
+        """
+        Estimate the smearing for ewald calculators.
 
         :param cell: A 3x3 tensor representing the periodic system
         :returns: estimated smearing
@@ -95,19 +93,18 @@ class CalculatorBaseTorch(torch.nn.Module):
 
     @staticmethod
     def _validate_compute_parameters(
-        positions: Union[List[torch.Tensor], torch.Tensor],
-        charges: Union[List[torch.Tensor], torch.Tensor],
-        cell: Union[List[torch.Tensor], torch.Tensor],
-        neighbor_indices: Union[List[torch.Tensor], torch.Tensor],
-        neighbor_distances: Union[List[torch.Tensor], torch.Tensor],
-    ) -> Tuple[
-        List[torch.Tensor],
-        List[torch.Tensor],
-        List[torch.Tensor],
-        List[torch.Tensor],
-        List[torch.Tensor],
+        positions: Union[list[torch.Tensor], torch.Tensor],
+        charges: Union[list[torch.Tensor], torch.Tensor],
+        cell: Union[list[torch.Tensor], torch.Tensor],
+        neighbor_indices: Union[list[torch.Tensor], torch.Tensor],
+        neighbor_distances: Union[list[torch.Tensor], torch.Tensor],
+    ) -> tuple[
+        list[torch.Tensor],
+        list[torch.Tensor],
+        list[torch.Tensor],
+        list[torch.Tensor],
+        list[torch.Tensor],
     ]:
-
         # check that all inputs are of the same type
         for item, item_name in (
             (charges, "charges"),
@@ -283,7 +280,8 @@ class CalculatorBaseTorch(torch.nn.Module):
         neighbor_indices: torch.Tensor,
         neighbor_distances: torch.Tensor,
     ) -> torch.Tensor:
-        """Core method for calculations for an individual atomic structure.
+        """
+        Core method for calculations for an individual atomic structure.
 
         The actual logic has to be implemented in each calculator. Each calculators'
         main (user-facing) :py:meth:`forward` method then simply loops over all
@@ -293,13 +291,14 @@ class CalculatorBaseTorch(torch.nn.Module):
 
     def forward(
         self,
-        positions: Union[List[torch.Tensor], torch.Tensor],
-        charges: Union[List[torch.Tensor], torch.Tensor],
-        cell: Union[List[torch.Tensor], torch.Tensor],
-        neighbor_indices: Union[List[torch.Tensor], torch.Tensor],
-        neighbor_distances: Union[List[torch.Tensor], torch.Tensor],
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        """Compute potential for all provided "systems" stacked inside list.
+        positions: Union[list[torch.Tensor], torch.Tensor],
+        charges: Union[list[torch.Tensor], torch.Tensor],
+        cell: Union[list[torch.Tensor], torch.Tensor],
+        neighbor_indices: Union[list[torch.Tensor], torch.Tensor],
+        neighbor_distances: Union[list[torch.Tensor], torch.Tensor],
+    ) -> Union[torch.Tensor, list[torch.Tensor]]:
+        """
+        Compute potential for all provided "systems" stacked inside list.
 
         The computation is performed on the same ``device`` as ``dtype`` is the input is
         stored on. The ``dtype`` of the output tensors will be the same as the input.
@@ -375,5 +374,4 @@ class CalculatorBaseTorch(torch.nn.Module):
 
         if input_is_list:
             return potentials
-        else:
-            return potentials[0]
+        return potentials[0]

--- a/src/torchpme/calculators/directpotential.py
+++ b/src/torchpme/calculators/directpotential.py
@@ -4,7 +4,8 @@ from .base import CalculatorBaseTorch
 
 
 class DirectPotential(CalculatorBaseTorch):
-    r"""Potential using a direct summation.
+    r"""
+    Potential using a direct summation.
 
     Scaling as :math:`\mathcal{O}(N^2)` with respect to the number of particles
     :math:`N`. As opposed to the Ewald sum, this calculator does NOT take into account
@@ -62,6 +63,7 @@ class DirectPotential(CalculatorBaseTorch):
 
     Which is the expected potential since :math:`V \propto 1/r` where :math:`r` is the
     distance between the particles.
+
     """
 
     def __init__(self, exponent: float = 1.0, full_neighbor_list: bool = False):
@@ -79,7 +81,6 @@ class DirectPotential(CalculatorBaseTorch):
         neighbor_indices: torch.Tensor,
         neighbor_distances: torch.Tensor,
     ) -> torch.Tensor:
-
         return self._compute_sr(
             is_periodic=False,
             charges=charges,

--- a/src/torchpme/calculators/ewaldpotential.py
+++ b/src/torchpme/calculators/ewaldpotential.py
@@ -8,7 +8,8 @@ from .base import CalculatorBaseTorch
 
 
 class EwaldPotential(CalculatorBaseTorch):
-    r"""Potential computed using the Ewald sum.
+    r"""
+    Potential computed using the Ewald sum.
 
     Scaling as :math:`\mathcal{O}(N^2)` with respect to the number of particles
     :math:`N`.
@@ -64,8 +65,7 @@ class EwaldPotential(CalculatorBaseTorch):
 
         if atomic_smearing is not None and atomic_smearing <= 0:
             raise ValueError(f"`atomic_smearing` {atomic_smearing} has to be positive")
-        else:
-            self.atomic_smearing = atomic_smearing
+        self.atomic_smearing = atomic_smearing
 
     def _compute_single_system(
         self,

--- a/src/torchpme/calculators/pmepotential.py
+++ b/src/torchpme/calculators/pmepotential.py
@@ -10,7 +10,8 @@ from .base import CalculatorBaseTorch
 
 
 class PMEPotential(CalculatorBaseTorch):
-    r"""Potential using a particle mesh-based Ewald (PME).
+    r"""
+    Potential using a particle mesh-based Ewald (PME).
 
     Scaling as :math:`\mathcal{O}(NlogN)` with respect to the number of particles
     :math:`N` used as a reference to test faster implementations.
@@ -90,6 +91,7 @@ class PMEPotential(CalculatorBaseTorch):
             [ 1.0192]], dtype=torch.float64)
 
     Which is close to the reference value given above.
+
     """
 
     def __init__(
@@ -112,13 +114,11 @@ class PMEPotential(CalculatorBaseTorch):
 
         if atomic_smearing is not None and atomic_smearing <= 0:
             raise ValueError(f"`atomic_smearing` {atomic_smearing} has to be positive")
-        else:
-            self.atomic_smearing = atomic_smearing
+        self.atomic_smearing = atomic_smearing
 
         if interpolation_order not in [1, 2, 3, 4, 5]:
             raise ValueError("Only `interpolation_order` from 1 to 5 are allowed")
-        else:
-            self.interpolation_order = interpolation_order
+        self.interpolation_order = interpolation_order
 
         # TorchScript requires to initialize all attributes in __init__
         self._cell_cache = -1 * torch.ones([3, 3])
@@ -193,7 +193,6 @@ class PMEPotential(CalculatorBaseTorch):
         smearing: float,
         lr_wavelength: float,
     ) -> torch.Tensor:
-
         dtype = positions.dtype
         device = positions.device
         self._cell_cache = self._cell_cache.to(dtype=dtype, device=device)

--- a/src/torchpme/lib/__init__.py
+++ b/src/torchpme/lib/__init__.py
@@ -1,11 +1,11 @@
-from .mesh_interpolator import MeshInterpolator
-from .potentials import InversePowerLawPotential
+from .kspace_filter import KSpaceFilter, KSpaceKernel
 from .kvectors import (
-    generate_kvectors_for_mesh,
     generate_kvectors_for_ewald,
+    generate_kvectors_for_mesh,
     get_ns_mesh,
 )
-from .kspace_filter import KSpaceFilter, KSpaceKernel
+from .mesh_interpolator import MeshInterpolator
+from .potentials import InversePowerLawPotential
 
 __all__ = [
     "all_neighbor_indices",

--- a/src/torchpme/lib/kspace_filter.py
+++ b/src/torchpme/lib/kspace_filter.py
@@ -4,7 +4,8 @@ from .kvectors import generate_kvectors_for_mesh
 
 
 class KSpaceKernel(torch.nn.Module):
-    r"""Base class defining the interface for a reciprocal-space kernel helper.
+    r"""
+    Base class defining the interface for a reciprocal-space kernel helper.
 
     Provides an interface to compute the reciprocal-space convolution kernel
     that is used e.g. to compute potentials using Fourier transforms. Parameters
@@ -20,30 +21,31 @@ class KSpaceKernel(torch.nn.Module):
         super().__init__()
 
     def from_k(self, k: torch.Tensor) -> torch.Tensor:
-        r"""Computes the reciprocal-space kernel on a grid of k points given a
+        r"""
+        Computes the reciprocal-space kernel on a grid of k points given a
         tensor containing :math:`|\mathbf{k}|`.
 
         :param k: torch.tensor containing the k vector moduli at which the kernel
             is to be evaluated.
         """
-
         return self.from_k_sq(k**2)
 
     def from_k_sq(self, k_sq: torch.Tensor) -> torch.Tensor:
-        r"""Computes the reciprocal-space kernel on a grid of k points given a
+        r"""
+        Computes the reciprocal-space kernel on a grid of k points given a
         tensor containing :math:`|\mathbf{k}|^2`.
 
         :param k_sq: torch.tensor containing the squared k vector moduli
             at which the kernel is to be evaluated.
         """
-
         raise NotImplementedError(
             f"from_k_sq is not implemented for '{self.__class__.__name__}'"
         )
 
 
 class KSpaceFilter(torch.nn.Module):
-    r"""Apply a reciprocal-space filter to a real-space mesh.
+    r"""
+    Apply a reciprocal-space filter to a real-space mesh.
 
     The class combines the costruction of a reciprocal-space grid
     :math:`\{mathbf{k}_n\}`
@@ -85,7 +87,6 @@ class KSpaceFilter(torch.nn.Module):
         fft_norm: str = "ortho",
         ifft_norm: str = "ortho",
     ):
-
         super().__init__()
 
         self._fft_norm = fft_norm
@@ -111,12 +112,12 @@ class KSpaceFilter(torch.nn.Module):
         :py:class:`KSpaceKernel`-derived object provided upon initialization
         to compute the kernel values over the grid points.
         """
-
         self._kfilter = self._kernel.from_k_sq(self._knorm_sq)
 
     @torch.jit.export
     def update_mesh(self, cell: torch.Tensor, ns_mesh: torch.Tensor):
-        """Update the k-space mesh vectors.
+        """
+        Update the k-space mesh vectors.
 
         Should have a size consistent with that of the mesh used to
         store the real-space functions that will be filtered.
@@ -126,7 +127,6 @@ class KSpaceFilter(torch.nn.Module):
         :param ns_mesh: toch.tensor of shape ``(3,)``
             Number of mesh points to use along each of the three axes
         """
-
         # Check that the provided parameters match the specifications
         if cell.shape != (3, 3):
             raise ValueError(
@@ -199,7 +199,7 @@ class KSpaceFilter(torch.nn.Module):
 
         filter_hat = mesh_hat * self._kfilter
 
-        mesh_kernel = torch.fft.irfftn(
+        return torch.fft.irfftn(
             filter_hat,
             norm=self._ifft_norm,
             dim=dims,
@@ -209,10 +209,9 @@ class KSpaceFilter(torch.nn.Module):
             s=mesh_values.shape[-3:],
         )
 
-        return mesh_kernel
-
     def forward(self, cell: torch.Tensor, mesh: torch.Tensor):
-        """Performs a full k-space convolution step.
+        """
+        Performs a full k-space convolution step.
 
         The default forward call for `KSpaceFilter` combines
         the construction or update of the mesh (including the
@@ -222,7 +221,6 @@ class KSpaceFilter(torch.nn.Module):
         The size of the mesh is inferred from the input mesh
         size.
         """
-
         self.update_mesh(cell, torch.tensor(mesh.shape[-3:]))
 
         return self.compute(mesh)

--- a/src/torchpme/lib/kvectors.py
+++ b/src/torchpme/lib/kvectors.py
@@ -17,8 +17,7 @@ def get_ns_mesh(cell: torch.Tensor, mesh_spacing: float):
     ns_approx = basis_norms / mesh_spacing
     ns_actual_approx = 2 * ns_approx + 1  # actual number of mesh points
     # ns = [nx, ny, nz], closest power of 2 (helps for FT efficiency)
-    ns = torch.tensor(2).pow(torch.ceil(torch.log2(ns_actual_approx)).long())
-    return ns
+    return torch.tensor(2).pow(torch.ceil(torch.log2(ns_actual_approx)).long())
 
 
 def _generate_kvectors(
@@ -67,7 +66,8 @@ def _generate_kvectors(
 
 
 def generate_kvectors_for_mesh(ns: torch.Tensor, cell: torch.Tensor) -> torch.Tensor:
-    """Compute all reciprocal space vectors for Fourier space sums.
+    """
+    Compute all reciprocal space vectors for Fourier space sums.
 
     This variant is used in combination with **mesh based calculators** using the fast
     fourier transform (FFT) algorithm.
@@ -94,7 +94,8 @@ def generate_kvectors_for_mesh(ns: torch.Tensor, cell: torch.Tensor) -> torch.Te
 
 
 def generate_kvectors_for_ewald(ns: torch.Tensor, cell: torch.Tensor) -> torch.Tensor:
-    """Compute all reciprocal space vectors for Fourier space sums.
+    """
+    Compute all reciprocal space vectors for Fourier space sums.
 
     This variant is used with the **Ewald calculator**, in which the sum over the
     reciprocal space vectors is performed explicitly rather than using the fast Fourier

--- a/src/torchpme/lib/mesh_interpolator.py
+++ b/src/torchpme/lib/mesh_interpolator.py
@@ -115,9 +115,9 @@ class MeshInterpolator:
             return torch.ones(
                 (1, x.shape[0], x.shape[1]), dtype=self._dtype, device=self._device
             )
-        elif self.interpolation_order == 2:
+        if self.interpolation_order == 2:
             return torch.stack([0.5 * (1 - 2 * x), 0.5 * (1 + 2 * x)])
-        elif self.interpolation_order == 3:
+        if self.interpolation_order == 3:
             x2 = x * x
             return torch.stack(
                 [
@@ -126,7 +126,7 @@ class MeshInterpolator:
                     1 / 8 * (1 + 4 * x + 4 * x2),
                 ]
             )
-        elif self.interpolation_order == 4:
+        if self.interpolation_order == 4:
             x2 = x * x
             x3 = x * x2
             return torch.stack(
@@ -137,7 +137,7 @@ class MeshInterpolator:
                     1 / 48 * (1 + 6 * x + 12 * x2 + 8 * x3),
                 ]
             )
-        elif self.interpolation_order == 5:
+        if self.interpolation_order == 5:
             x2 = x * x
             x3 = x * x2
             x4 = x * x3
@@ -150,8 +150,7 @@ class MeshInterpolator:
                     1 / 384 * (1 + 8 * x + 24 * x2 + 32 * x3 + 16 * x4),
                 ]
             )
-        else:
-            raise ValueError("Only `interpolation_order` from 1 to 5 are allowed")
+        raise ValueError("Only `interpolation_order` from 1 to 5 are allowed")
 
     def compute_interpolation_weights(self, positions: torch.Tensor):
         """
@@ -163,7 +162,6 @@ class MeshInterpolator:
         :param positions: torch.tensor of shape ``(N, 3)``
             Absolute positions of atoms in Cartesian coordinates
         """
-
         if positions.device != self._device:
             raise ValueError(
                 f"`positions` device {positions.device} is not the same as instance "
@@ -294,7 +292,7 @@ class MeshInterpolator:
                 "dimension 4"
             )
 
-        interpolated_values = (
+        return (
             (
                 mesh_vals[:, self.x_indices, self.y_indices, self.z_indices]
                 * self.interpolation_weights[self.x_shifts, :, 0]
@@ -304,5 +302,3 @@ class MeshInterpolator:
             .sum(dim=1)
             .T
         )
-
-        return interpolated_values

--- a/src/torchpme/lib/potentials.py
+++ b/src/torchpme/lib/potentials.py
@@ -15,7 +15,8 @@ def gamma(x: torch.Tensor) -> torch.Tensor:
 
 
 class BasePotential(torch.nn.Module):
-    r"""Base class defining the interface for a pair potential energy function.
+    r"""
+    Base class defining the interface for a pair potential energy function.
 
     Internal state variables and parameters in derived classes should be defined
     in the ``__init__``  method. Supports computing the potential starting from a
@@ -26,28 +27,29 @@ class BasePotential(torch.nn.Module):
         super().__init__()
 
     def from_dist(self, dist: torch.Tensor) -> torch.Tensor:
-        """Computes a pair potential given a tensor of interatomic distances.
+        """
+        Computes a pair potential given a tensor of interatomic distances.
 
         :param dist: torch.tensor containing the distances at which the potential
             is to be evaluated.
         """
-
         raise NotImplementedError(
             f"from_dist is not implemented for {self.__class__.__name__}"
         )
 
     def from_dist_sq(self, dist_sq: torch.Tensor) -> torch.Tensor:
-        """Computes a pair potential given a tensor of squared distances.
+        """
+        Computes a pair potential given a tensor of squared distances.
 
         :param dist_sq: torch.tensor containing the squared distances at which
             the potential is to be evaluated.
         """
-
         return self.from_dist(torch.sqrt(dist_sq))
 
 
 class RangeSeparatedPotential(BasePotential, KSpaceKernel):
-    r"""Base class defining the interface for a range-separated potential.
+    r"""
+    Base class defining the interface for a range-separated potential.
 
     Internal state variables and parameters in derived classes should be defined
     in the ``__init__``  method. It provides a short-range and long-range
@@ -84,7 +86,8 @@ class RangeSeparatedPotential(BasePotential, KSpaceKernel):
 
 
 class InversePowerLawPotential(RangeSeparatedPotential):
-    """Inverse power-law potentials of the form :math:`1/r^p`.
+    """
+    Inverse power-law potentials of the form :math:`1/r^p`.
 
     Herem :math:`r` is a distance parameter and :math:`p` an exponent.
 
@@ -123,7 +126,8 @@ class InversePowerLawPotential(RangeSeparatedPotential):
         return torch.pow(dist, -self.exponent)
 
     def from_dist_sq(self, dist_sq: torch.Tensor) -> torch.Tensor:
-        """Full :math:`1/r^p` potential as a function of :math:`r^2`.
+        """
+        Full :math:`1/r^p` potential as a function of :math:`r^2`.
 
         :param dist_sq: torch.tensor containing the squared distances at which the
             potential is to be evaluated.
@@ -131,7 +135,8 @@ class InversePowerLawPotential(RangeSeparatedPotential):
         return torch.pow(dist_sq, -self.exponent / 2.0)
 
     def sr_from_dist(self, dist: torch.Tensor) -> torch.Tensor:
-        r"""Short-range (SR) part of the range-separated :math:`1/r^p` potential.
+        r"""
+        Short-range (SR) part of the range-separated :math:`1/r^p` potential.
 
         More explicitly: it corresponds to `:math:`V_\mathrm{SR}(r)` in :math:`1/r^p =
         V_\mathrm{SR}(r) + V_\mathrm{LR}(r)`, where the location of the split is
@@ -150,12 +155,12 @@ class InversePowerLawPotential(RangeSeparatedPotential):
         x = 0.5 * dist**2 / self.smearing**2
         peff = exponent / 2
         prefac = 1.0 / (2 * self.smearing**2) ** peff
-        potential = prefac * gammaincc(peff, x) / x**peff
 
-        return potential
+        return prefac * gammaincc(peff, x) / x**peff
 
     def lr_from_dist(self, dist: torch.Tensor) -> torch.Tensor:
-        """LR part of the range-separated :math:`1/r^p` potential.
+        """
+        LR part of the range-separated :math:`1/r^p` potential.
 
         Used to subtract out the interior contributions after computing the LR part in
         reciprocal (Fourier) space.
@@ -174,11 +179,11 @@ class InversePowerLawPotential(RangeSeparatedPotential):
         x = 0.5 * dist**2 / self.smearing**2
         peff = exponent / 2
         prefac = 1.0 / (2 * self.smearing**2) ** peff
-        potential = prefac * gammainc(peff, x) / x**peff
-        return potential
+        return prefac * gammainc(peff, x) / x**peff
 
     def from_k_sq(self, k_sq: torch.Tensor) -> torch.Tensor:
-        """Fourier transform of the LR part potential in terms of :math:`k^2`.
+        """
+        Fourier transform of the LR part potential in terms of :math:`k^2`.
 
         If only the Coulomb potential is needed, the last line can be
         replaced by
@@ -208,9 +213,8 @@ class InversePowerLawPotential(RangeSeparatedPotential):
         # Fourier-transformed LR potential does not diverge as k->0, and one
         # could instead assign the correct limit. This is not implemented for now
         # for consistency reasons.
-        fourier = torch.where(
+        return torch.where(
             k_sq == 0,
             0.0,
             prefac * gammaincc(peff, x) / x**peff * gamma(peff),
         )
-        return fourier

--- a/src/torchpme/metatensor/__init__.py
+++ b/src/torchpme/metatensor/__init__.py
@@ -1,5 +1,5 @@
-from .ewaldpotential import EwaldPotential
 from .directpotential import DirectPotential
+from .ewaldpotential import EwaldPotential
 from .pmepotential import PMEPotential
 
 __all__ = ["EwaldPotential", "DirectPotential", "PMEPotential"]

--- a/src/torchpme/metatensor/base.py
+++ b/src/torchpme/metatensor/base.py
@@ -1,7 +1,6 @@
-from typing import List, Tuple, Union
+from typing import Union
 
 import torch
-
 
 try:
     from metatensor.torch import Labels, TensorBlock, TensorMap
@@ -10,7 +9,7 @@ except ImportError:
     raise ImportError(
         "metatensor.torch is required for torchpme.metatensor but is not installed. "
         "Try installing it with:\npip install metatensor[torch]"
-    )
+    ) from None
 
 
 class CalculatorBaseMetatensor(torch.nn.Module):
@@ -26,9 +25,9 @@ class CalculatorBaseMetatensor(torch.nn.Module):
 
     @staticmethod
     def _validate_compute_parameters(
-        systems: Union[List[System], System],
-        neighbors: Union[List[TensorBlock], TensorBlock],
-    ) -> Tuple[List[System], List[TensorBlock]]:
+        systems: Union[list[System], System],
+        neighbors: Union[list[TensorBlock], TensorBlock],
+    ) -> tuple[list[System], list[TensorBlock]]:
         # check that all inputs are of the same type
 
         if isinstance(systems, list):
@@ -46,8 +45,7 @@ class CalculatorBaseMetatensor(torch.nn.Module):
                     "a list, while `neighbors` is a list. Both need "
                     "either be a list or System/TensorBlock!"
                 )
-            else:
-                neighbors = [neighbors]
+            neighbors = [neighbors]
 
         if len(systems) != len(neighbors):
             raise ValueError(
@@ -143,10 +141,11 @@ class CalculatorBaseMetatensor(torch.nn.Module):
 
     def forward(
         self,
-        systems: Union[List[System], System],
-        neighbors: Union[List[TensorBlock], TensorBlock],
+        systems: Union[list[System], System],
+        neighbors: Union[list[TensorBlock], TensorBlock],
     ) -> TensorMap:
-        """Compute potential for all provided ``systems``.
+        """
+        Compute potential for all provided ``systems``.
 
         All ``systems`` must have the same ``dtype`` and the same ``device``. If each
         system contains a custom data field ``charges`` the potential will be calculated
@@ -176,8 +175,8 @@ class CalculatorBaseMetatensor(torch.nn.Module):
         self._device = systems[0].positions.device
         self._n_charges_channels = systems[0].get_data("charges").values.shape[1]
 
-        potentials: List[torch.Tensor] = []
-        samples_list: List[torch.Tensor] = []
+        potentials: list[torch.Tensor] = []
+        samples_list: list[torch.Tensor] = []
 
         for i_system, (system, neighbors_single) in enumerate(zip(systems, neighbors)):
             n_atoms = len(system)

--- a/src/torchpme/metatensor/directpotential.py
+++ b/src/torchpme/metatensor/directpotential.py
@@ -3,7 +3,8 @@ from .base import CalculatorBaseMetatensor
 
 
 class DirectPotential(CalculatorBaseMetatensor):
-    r"""Potential using a direct summation.
+    r"""
+    Potential using a direct summation.
 
     Refer to :class:`torchpme.DirectPotential` for parameter documentation.
 
@@ -90,6 +91,7 @@ class DirectPotential(CalculatorBaseMetatensor):
 
     Which is the expected potential since :math:`V \propto 1/r` where :math:`r` is the
     distance between the particles.
+
     """
 
     def __init__(self, exponent: float = 1.0, full_neighbor_list: bool = False):

--- a/src/torchpme/metatensor/ewaldpotential.py
+++ b/src/torchpme/metatensor/ewaldpotential.py
@@ -5,7 +5,8 @@ from .base import CalculatorBaseMetatensor
 
 
 class EwaldPotential(CalculatorBaseMetatensor):
-    r"""Potential computed using the Ewald sum.
+    r"""
+    Potential computed using the Ewald sum.
 
     Refer to :class:`torchpme.EwaldPotential` for parameter documentation.
 

--- a/src/torchpme/metatensor/pmepotential.py
+++ b/src/torchpme/metatensor/pmepotential.py
@@ -5,7 +5,8 @@ from .base import CalculatorBaseMetatensor
 
 
 class PMEPotential(CalculatorBaseMetatensor):
-    r"""Potential using a particle mesh-based Ewald (PME).
+    r"""
+    Potential using a particle mesh-based Ewald (PME).
 
     Refer to :class:`torchpme.PMEPotential` for parameter documentation.
 
@@ -96,6 +97,7 @@ class PMEPotential(CalculatorBaseMetatensor):
             [ 1.0192]], dtype=torch.float64)
 
     Which is close to the reference value given above.
+
     """
 
     def __init__(

--- a/tests/calculators/test_base.py
+++ b/tests/calculators/test_base.py
@@ -3,7 +3,6 @@ import torch
 
 from torchpme.calculators.base import CalculatorBaseTorch
 
-
 # Define some example parameters
 DTYPE = torch.float32
 DEVICE = "cpu"
@@ -27,7 +26,7 @@ class CalculatorTest(CalculatorBaseTorch):
         return charges
 
 
-@pytest.mark.parametrize("n_elements", (0, 1, 2))
+@pytest.mark.parametrize("n_elements", [0, 1, 2])
 def test_compute_output_shapes(n_elements):
     """Test that output type matches the input type"""
     calculator = CalculatorTest()

--- a/tests/calculators/test_values_direct.py
+++ b/tests/calculators/test_values_direct.py
@@ -6,7 +6,6 @@ from utils import neighbor_list_torch
 
 from torchpme import DirectPotential
 
-
 DTYPE = torch.float64
 
 
@@ -107,7 +106,6 @@ def define_molecule(molecule_name="dimer"):
 
 
 def generate_orthogonal_transformations():
-
     # first rotation matrix: identity
     rot_1 = torch.eye(3, dtype=DTYPE)
 

--- a/tests/calculators/test_values_ewald.py
+++ b/tests/calculators/test_values_ewald.py
@@ -11,7 +11,6 @@ from utils import neighbor_list_torch
 
 from torchpme import EwaldPotential, PMEPotential
 
-
 DTYPE = torch.float64
 
 

--- a/tests/calculators/test_workflow.py
+++ b/tests/calculators/test_workflow.py
@@ -10,7 +10,6 @@ from torch.testing import assert_close
 
 from torchpme import DirectPotential, EwaldPotential, PMEPotential
 
-
 AVAILABLE_DEVICES = [torch.device("cpu")] + torch.cuda.is_available() * [
     torch.device("cuda")
 ]

--- a/tests/calculators/utils.py
+++ b/tests/calculators/utils.py
@@ -1,6 +1,6 @@
 """Test utilities wrap common functions in the tests"""
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 from vesin.torch import NeighborList
@@ -12,8 +12,7 @@ def neighbor_list_torch(
     box: Optional[torch.tensor] = None,
     cutoff: Optional[float] = None,
     full_neighbor_list: bool = False,
-) -> Tuple[torch.tensor, torch.tensor]:
-
+) -> tuple[torch.tensor, torch.tensor]:
     if box is None:
         box = torch.zeros(3, 3, dtype=positions.dtype, device=positions.device)
 

--- a/tests/lib/test_kspace_filter.py
+++ b/tests/lib/test_kspace_filter.py
@@ -16,8 +16,7 @@ class TestKernel:
 
         @torch.jit.export
         def from_k_sq(self, k_sq: torch.Tensor) -> torch.Tensor:
-            kernel = torch.exp(-k_sq / self.param)
-            return kernel
+            return torch.exp(-k_sq / self.param)
 
     class NoopKernel(KSpaceKernel):
         def __init__(self):
@@ -25,8 +24,7 @@ class TestKernel:
 
         @torch.jit.export
         def from_k_sq(self, k_sq: torch.Tensor) -> torch.Tensor:
-            kernel = torch.ones_like(k_sq)
-            return kernel
+            return torch.ones_like(k_sq)
 
     def test_kernel_subclassing(self):
         # check that one can define and use a kernel
@@ -35,7 +33,6 @@ class TestKernel:
         my_krn.from_k_sq(k_sq)
 
     def test_kernel_jitting(self):
-
         # pytorch
         my_krn = self.DemoKernel(1.0)
         k_sq = torch.arange(0, 10, 0.01)
@@ -49,7 +46,6 @@ class TestKernel:
 
 
 class TestFilter:
-
     cell1 = torch.randn((3, 3))
     cell2 = torch.randn((3, 3))
     ns1 = torch.tensor([3, 4, 5])

--- a/tests/lib/test_kvectors.py
+++ b/tests/lib/test_kvectors.py
@@ -4,7 +4,6 @@ from torch.testing import assert_close
 
 from torchpme.lib import generate_kvectors_for_ewald, generate_kvectors_for_mesh
 
-
 # Generate random cells and mesh parameters
 cells = []
 ns_list = []

--- a/tests/metatensor/test_base_metatensor.py
+++ b/tests/metatensor/test_base_metatensor.py
@@ -5,7 +5,6 @@ from packaging import version
 import torchpme
 import torchpme.calculators
 
-
 mts_torch = pytest.importorskip("metatensor.torch")
 mts_atomistic = pytest.importorskip("metatensor.torch.atomistic")
 
@@ -47,14 +46,13 @@ def neighbors():
     )
 
     values = torch.zeros(n_neighbors, 3, 1)
-    neighbors = mts_torch.TensorBlock(
+
+    return mts_torch.TensorBlock(
         values=values,
         samples=samples,
         components=[mts_torch.Labels.range("xyz", 3)],
         properties=mts_torch.Labels.range("distance", 1),
     )
-
-    return neighbors
 
 
 class CalculatorTestTorch(torchpme.calculators.base.CalculatorBaseTorch):

--- a/tests/metatensor/test_workflow_metatensor.py
+++ b/tests/metatensor/test_workflow_metatensor.py
@@ -10,7 +10,6 @@ from packaging import version
 
 import torchpme
 
-
 mts_torch = pytest.importorskip("metatensor.torch")
 mts_atomistic = pytest.importorskip("metatensor.torch.atomistic")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,4 +2,4 @@ import torchpme
 
 
 def test_version_exist():
-    torchpme.__version__
+    _ = torchpme.__version__

--- a/tox.ini
+++ b/tox.ini
@@ -61,19 +61,12 @@ commands =
 description = Run linters and type checks
 package = skip
 deps =
-    black
-    blackdoc
-    flake8
-    flake8-bugbear
-    flake8-sphinx-links
+    ruff
     mypy
-    isort
     sphinx-lint
 commands =
-    flake8 {[testenv]lint_folders}
-    black --check --diff {[testenv]lint_folders}
-    blackdoc --check --diff {[testenv]lint_folders} "{toxinidir}/README.rst"
-    isort --check-only --diff {[testenv]lint_folders}
+    ruff format --diff {[testenv]lint_folders}
+    ruff check {[testenv]lint_folders}
     mypy {[testenv]lint_folders}
     sphinx-lint \
         --enable all \
@@ -84,14 +77,10 @@ commands =
 [testenv:format]
 description = Abuse tox to do actual formatting on all files.
 package = skip
-deps =
-    black
-    blackdoc
-    isort
+deps = ruff
 commands =
-    black {[testenv]lint_folders}
-    blackdoc {[testenv]lint_folders} "{toxinidir}/README.rst"
-    isort {[testenv]lint_folders}
+    ruff format {[testenv]lint_folders}
+    ruff check --fix-only {[testenv]lint_folders}
 
 [testenv:docs]
 description = Building the package documentation.
@@ -104,12 +93,3 @@ extras =
     metatensor
 commands =
     sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
-
-[flake8]
-max_line_length = 88
-exclude =
-    docs/src/examples/
-per-file-ignores =
-    # D205 and D400 are incompatible with the requirements of sphinx-gallery
-    examples/**:D205, D400
-extend-ignore = E203


### PR DESCRIPTION
>  Use Ruff they say, it is less annoying they say.

Switching from `black`/`isort`/`flake8` to `ruff`. I selected common rules which are mostly automatically fixable.

The workflow `tox -e lint` and `tox -e format` stays untouched.

Even though ruff offers a [docstring check](https://docs.astral.sh/ruff/rules/#pydocstyle-d) I decided after playing around it is too annoying in this state of the project. The docstring changes you see are from my tries. I think we can keep them but the linter will not complain if we change them in the future.

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--65.org.readthedocs.build/en/65/

<!-- readthedocs-preview torch-pme end -->