### PR TITLE
Cleanup `update` functions

### DIFF
--- a/docs/src/references/lib/kspace_filter.rst
+++ b/docs/src/references/lib/kspace_filter.rst
@@ -1,0 +1,6 @@
+Kspace filter
+=============
+
+.. automodule:: torchpme.lib.kspace_filter
+    :members:
+    :undoc-members:

--- a/examples/4-kspace-demo.py
+++ b/examples/4-kspace-demo.py
@@ -67,10 +67,12 @@ class GaussianSmearingKernel(torchpme.lib.KSpaceKernel):
 
 
 # This is the filter
-KF = torchpme.lib.KSpaceFilter(cell, ns_mesh, kernel=GaussianSmearingKernel(sigma2=1.0))
+kernel_filter = torchpme.lib.KSpaceFilter(
+    cell, ns_mesh, kernel=GaussianSmearingKernel(sigma2=1.0)
+)
 
 # Apply the filter to the mesh
-mesh_filtered = KF.compute(mesh_value)
+mesh_filtered = kernel_filter.forward(mesh_value)
 
 # %%
 # Visualize the effect of the filter
@@ -209,21 +211,16 @@ class MultiKernel(torchpme.lib.KSpaceKernel):
 # This can be used just as a simple filter
 
 multi_kernel = MultiKernel(torch.tensor([0.25, 0.5, 1.0], dtype=dtype, device=device))
-multi_KF = torchpme.lib.KSpaceFilter(cell, ns_mesh, kernel=multi_kernel)
-multi_filtered = multi_KF.compute(multi_mesh)
+multi_kernel_filter = torchpme.lib.KSpaceFilter(cell, ns_mesh, kernel=multi_kernel)
+multi_filtered = multi_kernel_filter.forward(multi_mesh)
 
 # %%
-# When the parameters of the kernel are modified,
+# When the parameters of the kernel or the ``cell`` are modified, one has to call
+# :py:func:`KSpaceFilter.update` before applying the filter
 
 multi_kernel._sigma = torch.tensor([1.0, 0.5, 0.25])
-multi_KF.update(cell=cell, ns_mesh=ns_mesh)
-multi_filtered_2 = multi_KF.compute(multi_mesh)
-
-# NB: when one needs to perform a full update, including the
-# cell, it is possible to call the ``forward`` function of the
-# class
-
-multi_filtered_3 = multi_KF(cell, multi_mesh)
+multi_kernel_filter.update(cell)
+multi_filtered_2 = multi_kernel_filter.forward(multi_mesh)
 
 # %%
 # Visualize the application of the filters
@@ -286,17 +283,17 @@ fig.colorbar(cfs[0], cax=cbar_ax, orientation="vertical")
 # The k-space filter can also be compiled to torch-script, for
 # faster execution (the impact is marginal for this very simple case)
 
-multi_filtered = multi_KF.compute(multi_mesh)
+multi_filtered = multi_kernel_filter.forward(multi_mesh)
 start = time()
 for _i in range(100):
-    multi_filtered = multi_KF.compute(multi_mesh)
+    multi_filtered = multi_kernel_filter.forward(multi_mesh)
 time_python = (time() - start) * 1e6 / 100
 
-jitted_KF = torch.jit.script(multi_KF)
-jit_filtered = jitted_KF.compute(multi_mesh)
+jitted_kernel_filter = torch.jit.script(multi_kernel_filter)
+jit_filtered = jitted_kernel_filter.forward(multi_mesh)
 start = time()
 for _i in range(100):
-    jit_filtered = jitted_KF.compute(multi_mesh)
+    jit_filtered = jitted_kernel_filter.forward(multi_mesh)
 time_jit = (time() - start) * 1e6 / 100
 
 print(f"Evaluation time:\nPytorch: {time_python}µs\nJitted:  {time_jit}µs")

--- a/examples/5-autograd-demo.py
+++ b/examples/5-autograd-demo.py
@@ -246,9 +246,9 @@ interpolator.compute_weights(positions)
 mesh = interpolator.points_to_mesh(weights)
 
 kernel = ParametricKernel(sigma, a0)
-KF = torchpme.lib.KSpaceFilter(cell, ns, kernel=kernel)
+kernel_filter = torchpme.lib.KSpaceFilter(cell, ns, kernel=kernel)
 
-filtered = KF.compute(mesh)
+filtered = kernel_filter.forward(mesh)
 
 filtered_at_positions = interpolator.mesh_to_points(filtered)
 
@@ -336,7 +336,7 @@ class KSpaceModule(torch.nn.Module):
             interpolation_nodes=3,
             method="Lagrange",
         )
-        self._KF = torchpme.lib.KSpaceFilter(
+        self._kernel_filter = torchpme.lib.KSpaceFilter(
             cell=dummy_cell,
             ns_mesh=torch.tensor([1, 1, 1]),
             kernel=SmearedCoulomb(self._sigma2),
@@ -367,8 +367,8 @@ class KSpaceModule(torch.nn.Module):
         self._mesh_interpolator.compute_weights(positions)
         mesh = self._mesh_interpolator.points_to_mesh(charges)
 
-        self._KF.update(cell, ns_mesh)
-        mesh = self._KF.compute(mesh)
+        self._kernel_filter.update(cell, ns_mesh)
+        mesh = self._kernel_filter.forward(mesh)
         pot = self._mesh_interpolator.mesh_to_points(mesh)
 
         x = torch.hstack([charges, pot])

--- a/examples/6-splined-potential.py
+++ b/examples/6-splined-potential.py
@@ -374,10 +374,10 @@ rho_mesh = mesh_interpolator.points_to_mesh(particle_weights=charges)
 ivolume = torch.abs(cell.det()).pow(-1)
 
 kernel_exclusion.update(cell, ns)
-coulomb_mesh = kernel_exclusion.compute(rho_mesh) * ivolume
+coulomb_mesh = kernel_exclusion.forward(rho_mesh) * ivolume
 
 kernel_spline.update(cell, ns)
-spline_mesh = kernel_spline.compute(rho_mesh) * ivolume
+spline_mesh = kernel_spline.forward(rho_mesh) * ivolume
 
 # %%
 # The potential computed using :py:class:`SplinePotential

--- a/src/torchpme/calculators/pme.py
+++ b/src/torchpme/calculators/pme.py
@@ -114,7 +114,7 @@ class PMECalculator(Calculator):
             rho_mesh = self.mesh_interpolator.points_to_mesh(particle_weights=charges)
 
         with profiler.record_function("step 2: perform actual convolution using FFT"):
-            potential_mesh = self.kspace_filter.compute(rho_mesh)
+            potential_mesh = self.kspace_filter.forward(rho_mesh)
 
         with profiler.record_function("step 3: back interpolation + volume scaling"):
             ivolume = torch.abs(cell.det()).pow(-1)

--- a/src/torchpme/lib/kspace_filter.py
+++ b/src/torchpme/lib/kspace_filter.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 import torch
 
@@ -53,8 +53,8 @@ class KSpaceFilter(torch.nn.Module):
     :math:`f\rightarrow \hat{f} \rightarrow \hat{\tilde{f}}=
     \hat{f} \phi \rightarrow \tilde{f}`
 
-    See also the :ref:`example-kspace` for a demonstration of the
-    functionalities of this class.
+    See also the :ref:`example-kspace-demo` for a demonstration of the functionalities
+    of this class.
 
     :param cell: torch.tensor of shape ``(3, 3)``, where ``cell[i]`` is the i-th basis
         vector of the unit cell
@@ -93,52 +93,71 @@ class KSpaceFilter(torch.nn.Module):
                 f"Invalid option '{ifft_norm}' for the `ifft_norm` parameter."
             )
 
-        self._kernel = kernel
+        self.kernel = kernel
         self.update(cell, ns_mesh)
 
     @torch.jit.export
-    def update(self, cell: torch.Tensor, ns_mesh: torch.Tensor):
-        """Update the k-space mesh vectors.
+    def update(
+        self,
+        cell: Optional[torch.Tensor] = None,
+        ns_mesh: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Update buffers and derived attributes of the instance.
 
-        Should have a size consistent with that of the mesh used to
-        store the real-space functions that will be filtered.
+        If neither ``cell`` nor ``ns_mesh`` are passed, only the filter is updated,
+        typically following a change in the underlying potential. If ``cell`` and/or
+        ``ns_mesh`` are given, the instance's attributes required by these will also be
+        updated accordingly.
 
         :param cell: torch.tensor of shape ``(3, 3)``, where `
             `cell[i]`` is the i-th basis vector of the unit cell
         :param ns_mesh: toch.tensor of shape ``(3,)``
             Number of mesh points to use along each of the three axes
         """
-        # Check that the provided parameters match the specifications
-        if cell.shape != (3, 3):
-            raise ValueError(
-                f"cell of shape {list(cell.shape)} should be of shape (3, 3)"
-            )
-        if ns_mesh.shape != (3,):
-            raise ValueError(f"shape {list(ns_mesh.shape)} of `ns_mesh` has to be (3,)")
-        if cell.device != ns_mesh.device:
+        if cell is not None:
+            if cell.shape != (3, 3):
+                raise ValueError(
+                    f"cell of shape {list(cell.shape)} should be of shape (3, 3)"
+                )
+            self.cell = cell
+
+        if ns_mesh is not None:
+            if ns_mesh.shape != (3,):
+                raise ValueError(
+                    f"shape {list(ns_mesh.shape)} of `ns_mesh` has to be (3,)"
+                )
+            self.ns_mesh = ns_mesh
+
+        if self.cell.device != self.ns_mesh.device:
             raise ValueError(
                 "`cell` and `ns_mesh` are on different devices, got "
-                f"{cell.device} and {ns_mesh.device}"
+                f"{self.cell.device} and {self.ns_mesh.device}"
             )
 
-        self._cell = cell
-        self._ns_mesh = ns_mesh
-        self._kvectors = generate_kvectors_for_mesh(ns=ns_mesh, cell=cell)
-        self._knorm_sq = torch.linalg.norm(self._kvectors, dim=3) ** 2
-        # also updates kfilter to reduce the risk it'd go out of sync
-        self._kfilter = self._kernel.kernel_from_k_sq(self._knorm_sq)
+        if cell is not None or ns_mesh is not None:
+            self._kvectors = generate_kvectors_for_mesh(ns=self.ns_mesh, cell=self.cell)
+            self._k_sq = torch.linalg.norm(self._kvectors, dim=3) ** 2
 
-    @torch.jit.export
-    def compute(
-        self,
-        mesh_values: torch.Tensor,
-    ) -> torch.Tensor:
+        # always update the kfilter to reduce the risk it'd go out of sync if the is an
+        # update in the underlaying potential
+        self._kfilter = self.kernel.kernel_from_k_sq(self._k_sq)
+
+    def forward(self, mesh_values: torch.Tensor) -> torch.Tensor:
         """
         Applies the k-space filter by Fourier transforming the given
         ``mesh_values`` tensor, multiplying the result by the filter array
         (that should have been previously computed with a call to
         :py:func:`update`) and Fourier-transforming back
         to real space.
+
+        If you update the ``cell``, the ``ns_mesh`` or anything inside the ``kernel``
+        object after you initlized the object, you have call :meth:`update` to update
+        the object calling this method.
+
+        .. code-block:: python
+
+            kernel_filter.update(cell)
+            kernel_filter.forward(mesh)
 
         :param mesh_values: torch.tensor of shape ``(n_channels, nx, ny, nz)``
             The values of the input function on a real-space mesh. Shape
@@ -189,19 +208,3 @@ class KSpaceFilter(torch.nn.Module):
             # well-defined
             s=mesh_values.shape[-3:],
         )
-
-    def forward(self, cell: torch.Tensor, mesh: torch.Tensor):
-        """
-        Performs a full k-space convolution step.
-
-        The default forward call for `KSpaceFilter` combines
-        the construction or update of the mesh (including the
-        calculation of the filter values) and the Fourier
-        convolution with a given grid.
-
-        The size of the mesh is inferred from the input mesh
-        size.
-        """
-        self.update(cell, torch.tensor(mesh.shape[-3:]))
-
-        return self.compute(mesh)

--- a/tests/lib/test_kvectors.py
+++ b/tests/lib/test_kvectors.py
@@ -28,7 +28,7 @@ def test_duality_of_kvectors_mesh(cell, ns):
     between them needs to satisfy a_j*b_l=2pi*delta_jl.
     """
     nx, ny, nz = ns
-    kvectors = generate_kvectors_for_mesh(ns=ns, cell=cell)
+    kvectors = generate_kvectors_for_mesh(cell=cell, ns=ns)
 
     # Define frequencies with the same convention as in FFT
     # This is essentially a manual implementation of torch.fft.fftfreq
@@ -55,7 +55,7 @@ def test_duality_of_kvectors_squeezed(cell, ns):
     between them needs to satisfy a_j*b_l=2pi*delta_jl.
     """
     nx, ny, nz = ns
-    kvectors = generate_kvectors_for_ewald(ns=ns, cell=cell)
+    kvectors = generate_kvectors_for_ewald(cell=cell, ns=ns)
 
     # Define frequencies with the same convention as in FFT
     # This is essentially a manual implementation of torch.fft.fftfreq
@@ -95,10 +95,10 @@ def test_lenghts_of_kvectors(cell, ns, kvec_type):
 
     # Compute the norms of all kvectors and check that they satisfy the bound
     if kvec_type == "fft":
-        kvectors = generate_kvectors_for_mesh(ns=ns, cell=cell)
+        kvectors = generate_kvectors_for_mesh(cell=cell, ns=ns)
         norms_all = torch.linalg.norm(kvectors, dim=3).flatten()
     elif kvec_type == "ewald":
-        kvectors = generate_kvectors_for_ewald(ns=ns, cell=cell)
+        kvectors = generate_kvectors_for_ewald(cell=cell, ns=ns)
         norms_all = torch.linalg.norm(kvectors, dim=1).flatten()
 
     assert torch.all(norms_all < norm_bound)
@@ -112,7 +112,7 @@ def test_ns_wrong_shape(generate_kvectors):
     cell = torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     match = "ns of shape \\[2\\] should be of shape \\(3, \\)"
     with pytest.raises(ValueError, match=match):
-        generate_kvectors(ns, cell)
+        generate_kvectors(cell=cell, ns=ns)
 
 
 @pytest.mark.parametrize("generate_kvectors", kvec_generators)
@@ -121,7 +121,7 @@ def test_cell_wrong_shape(generate_kvectors):
     cell = torch.tensor([[1, 0, 0], [0, 1, 0]])
     match = "cell of shape \\[2, 3\\] should be of shape \\(3, 3\\)"
     with pytest.raises(ValueError, match=match):
-        generate_kvectors(ns, cell)
+        generate_kvectors(cell=cell, ns=ns)
 
 
 @pytest.mark.parametrize("generate_kvectors", kvec_generators)
@@ -130,7 +130,7 @@ def test_different_devices_mesh_values_cell(generate_kvectors):
     cell = torch.eye(3, device="meta")  # different device
     match = "`ns` and `cell` are not on the same device, got cpu and meta"
     with pytest.raises(ValueError, match=match):
-        generate_kvectors(ns, cell)
+        generate_kvectors(cell=cell, ns=ns)
 
 
 @pytest.mark.parametrize("cell", cells)


### PR DESCRIPTION
An aftermath after #85. 

I made the update functions of the `MeshInterpolator` and `KSpaceFilter` consistent. So now can take either a `cell` and/or `ns_mesh`, which might be useful.

I also made the order of parameters consistent between the update methods and the `generate_kvectors` functions. Now all of these take the `cell` as first argument and the `ns_mesh` as second.

And finally I remove the `compute` method of the `KSpaceFilter` class. This method was basically calling `update` and then forward, which was very hard to follow when not looking at the code. I think the current design with one forward and a flexible `update` method. 

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--91.org.readthedocs.build/en/91/

<!-- readthedocs-preview torch-pme end -->