### PR TITLE
Add a check on the positivity of `sum_squared_charges`

### DIFF
--- a/src/torchpme/utils/tuning.py
+++ b/src/torchpme/utils/tuning.py
@@ -77,7 +77,7 @@ def tune_ewald(
         values typically result in accuracies around :math:`10^{-7}`.
 
 
-    :param sum_squared_charges: accumulated squared charges
+    :param sum_squared_charges: accumulated squared charges, must be positive
     :param cell: single tensor of shape (3, 3), describing the bounding
     :param positions: single tensor of shape (``len(charges), 3``) containing the
         Cartesian positions of all point charges in the system.
@@ -118,7 +118,7 @@ def tune_ewald(
     0.5485209762493759
     """
 
-    _validate_parameters(cell, positions, exponent)
+    _validate_parameters(sum_squared_charges, cell, positions, exponent)
 
     if not isinstance(accuracy, float):
         raise ValueError(f"'{accuracy}' is not a float.")
@@ -215,7 +215,7 @@ def tune_pme(
         setting ``max_steps = 0``. This can be useful if fast tuning is required. These
         values typically result in accuracies around :math:`10^{-2}`.
 
-    :param sum_squared_charges: accumulated squared charges
+    :param sum_squared_charges: accumulated squared charges, must be positive
     :param cell: single tensor of shape (3, 3), describing the bounding
     :param positions: single tensor of shape (``len(charges), 3``) containing the
         Cartesian positions of all point charges in the system.
@@ -262,7 +262,7 @@ def tune_pme(
     0.15078003506282253
     """
 
-    _validate_parameters(cell, positions, exponent)
+    _validate_parameters(sum_squared_charges, cell, positions, exponent)
 
     if not isinstance(accuracy, float):
         raise ValueError(f"'{accuracy}' is not a float.")
@@ -382,7 +382,16 @@ def _estimate_smearing(
     return max_cutoff.item() / 5.0
 
 
-def _validate_parameters(cell: torch.Tensor, positions: torch.Tensor, exponent: int):
+def _validate_parameters(
+    sum_squared_charges: float,
+    cell: torch.Tensor,
+    positions: torch.Tensor,
+    exponent: int,
+):
+    if sum_squared_charges <= 0:
+        raise ValueError(
+            f"sum of squared charges must be positive, got {sum_squared_charges}"
+        )
     dtype = positions.dtype
     device = positions.device
     if exponent != 1:

--- a/tests/utils/test_tuning.py
+++ b/tests/utils/test_tuning.py
@@ -121,6 +121,19 @@ def test_skip_optimization(tune):
 
 
 @pytest.mark.parametrize("tune", [tune_ewald, tune_pme])
+def test_non_positive_charge_error(tune):
+    pos, _, cell, _, _ = define_crystal()
+
+    match = "sum of squared charges must be positive, got -1.0"
+    with pytest.raises(ValueError, match=match):
+        tune(-1.0, cell, pos)
+
+    match = "sum of squared charges must be positive, got 0.0"
+    with pytest.raises(ValueError, match=match):
+        tune(0.0, cell, pos)
+
+
+@pytest.mark.parametrize("tune", [tune_ewald, tune_pme])
 def test_accuracy_error(tune):
     pos, charges, cell, _, _ = define_crystal()
 


### PR DESCRIPTION
Currently, there is no check on `sum_squared_charges`, which should be a positive number. This PR introduces a check: if the user gives a non-positive number, we throw an error.

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--93.org.readthedocs.build/en/93/

<!-- readthedocs-preview torch-pme end -->