### PR TITLE
Update to metatensor-torch 0.6

### DIFF
--- a/examples/1-charges-example.py
+++ b/examples/1-charges-example.py
@@ -42,6 +42,7 @@ symbols = ("Cs", "Cl")
 types = torch.tensor([55, 17])
 positions = torch.tensor([(0, 0, 0), (0.5, 0.5, 0.5)], dtype=torch.float64)
 cell = torch.eye(3, dtype=torch.float64)
+pbc = torch.tensor([True, True, True])
 
 
 # %%
@@ -202,7 +203,7 @@ calculator_metatensor = torchpme.metatensor.PMECalculator(
 #    only on the charge of the atom, NOT on the atom's type. However, we still have to
 #    pass them because it is an obligatory parameter to build the `System` class.
 
-system = System(types=types, positions=positions, cell=cell)
+system = System(types=types, positions=positions, cell=cell, pbc=pbc)
 
 # %%
 #

--- a/examples/2-neighbor-lists-usage.py
+++ b/examples/2-neighbor-lists-usage.py
@@ -56,7 +56,7 @@ atoms_unitcell = ase.Atoms(
     symbols=["Cs", "Cl"],
     positions=np.array([(0, 0, 0), (0.5, 0.5, 0.5)]),
     cell=np.eye(3),
-    pbc=True,
+    pbc=torch.tensor([True, True, True]),
 )
 charges_unitcell = np.array([1.0, -1.0])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ examples = [
     "vesin >= 0.2.0",
     "vesin-torch >= 0.2.0",
 ]
-metatensor = ["metatensor-torch <0.6,>=0.5"]
+metatensor = ["metatensor-torch <0.7,>=0.6"]
 
 [project.urls]
 homepage = "http://torch-pme.readthedocs.io"

--- a/tests/metatensor/test_base_metatensor.py
+++ b/tests/metatensor/test_base_metatensor.py
@@ -15,6 +15,7 @@ def system():
         types=torch.tensor([1, 2, 2]),
         positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.2], [0.0, 0.0, 0.5]]),
         cell=4.2 * torch.eye(3),
+        pbc=torch.tensor([True, True, True]),
     )
 
     charges = torch.tensor([1.0, -0.5, -0.5]).unsqueeze(1)
@@ -166,7 +167,7 @@ def test_wrong_neighbors_properties(system, neighbors):
 
 def test_wrong_system_not_all_charges(system, neighbors):
     system_nocharge = mts_torch.atomistic.System(
-        system.types, system.positions, system.cell
+        system.types, system.positions, system.cell, pbc=system.pbc
     )
 
     calculator = CalculatorTest()
@@ -177,7 +178,9 @@ def test_wrong_system_not_all_charges(system, neighbors):
 
 
 def test_different_number_charge_channels(system, neighbors):
-    system_channels = mts_atomistic.System(system.types, system.positions, system.cell)
+    system_channels = mts_atomistic.System(
+        system.types, system.positions, system.cell, pbc=system.pbc
+    )
 
     charges2 = torch.tensor([[1.0, 2.0], [-1.0, -2.0]])
     data2 = mts_torch.TensorBlock(
@@ -205,6 +208,7 @@ def test_systems_with_different_number_of_atoms(system, neighbors):
         types=torch.tensor([1, 1, 8]),
         positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0], [0.0, 2.0, 2.0]]),
         cell=torch.zeros([3, 3]),
+        pbc=torch.tensor([True, True, True]),
     )
 
     charges = torch.tensor([1.0, -1.0, 2.0]).unsqueeze(1)

--- a/tests/metatensor/test_workflow_metatensor.py
+++ b/tests/metatensor/test_workflow_metatensor.py
@@ -54,6 +54,7 @@ class TestWorkflow:
             types=torch.tensor([1, 2, 2]),
             positions=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.2], [0.0, 0.0, 0.5]]),
             cell=4.2 * torch.eye(3),
+            pbc=torch.tensor([True, True, True]),
         )
 
         charges = torch.tensor([1.0, -0.5, -0.5]).unsqueeze(1)


### PR DESCRIPTION
which made `pbc` argument required to init a `System`.

This should fix the issues we have in #92 

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--95.org.readthedocs.build/en/95/

<!-- readthedocs-preview torch-pme end -->