### PR TITLE
Add very basic docstring linting/formatting

### DIFF
--- a/examples/7-lode-demo.py
+++ b/examples/7-lode-demo.py
@@ -237,9 +237,7 @@ fig.show()
 
 
 def get_theta_phi_quadrature(L):
-    """
-    Legendre quadrature nodes for integrals over theta, phi
-    """
+    """Legendre quadrature nodes for integrals over theta, phi"""
     quads = []
     weights = []
     for w_index in range(0, 2 * L - 1):
@@ -258,7 +256,6 @@ def get_radial_quadrature(order, R):
     Generates Gauss-Legendre quadrature nodes and weights for radial integration
     in spherical coordinates over the interval [0, R].
     """
-
     gl_nodes, gl_weights = np.polynomial.legendre.leggauss(order)
     nodes = (R / 2) * (gl_nodes + 1)
     weights = (R / 2) ** 3 * gl_weights * (gl_nodes + 1) ** 2
@@ -494,10 +491,7 @@ lode_features = my_lode.forward(
 
 
 def value_to_seismic(value, vrange=0.1):
-    """
-    Maps a value within [vmin, vmax] to an RGB color string using the 'seismic' colormap.
-    """
-
+    """Map values to RGB color string using the 'seismic' colormap."""
     vmin, vmax = -vrange, vrange
     # Ensure the value is within the specified range
     clipped_value = np.clip(value, vmin, vmax)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,40 @@ exclude = ["docs/src/examples/**"]
 line-length = 88
 
 [tool.ruff.lint]
-# See https://docs.astral.sh/ruff/rules for details
-extend-select = ["B", "E", "UP", "I", "SIM", "PT", "RET", "W", "Q"]
+# See https://docs.astral.sh/ruff/rules for additional details
+extend-select = [
+    "B",  # Pyflakes checks (e.g., unused imports, undefined variables)
+    "D",  # PEP 257 docstring conventions (e.g., formatting, consistency)
+    "E",  # Pycodestyle errors (e.g., indentation, whitespace, syntax)
+    "UP",  # PyUpgrade rules (e.g., upgrading to modern Python syntax)
+    "I",  # Import conventions (e.g., sorting imports, duplicate imports)
+    "SIM",  # Simplification suggestions (e.g., refactoring redundant code)
+    "PT",  # Pytest style rules (e.g., avoiding assert in tests)
+    "RET",  # Return statements consistency (e.g., avoiding multiple return paths)
+    "W",  # Warnings about style (e.g., trailing whitespace, blank lines)
+    "Q",  # Quotes consistency (e.g., single vs. double quotes)
+]
 
-# E501: don't worry about too long lines
-ignore = ["E501"]
+ignore = [
+    "D100",  # Missing docstring in public module
+    "D102",  # Missing docstring in public method
+    "D104",  # Missing docstring in public package
+    "D107",  # Missing docstring in __init__
+    "D203",  # 1 blank line required before class docstring
+    "D205",  # 1 blank line required between summary line and description
+    "D212",  # Multi-line docstring summary should start at the first line
+    "D400",  # First line should end with a period
+    "D401",  # First line should be in imperative mood
+    "D403",  # First word of the first line should be capitalized
+    "D404",  # First word of the docstring should not be This
+    "D412",  # No blank lines allowed between a section header and its conten
+    "D415",  # First line should end with a period, question mark, or exclamation point
+    "D416",  # Section name should end with a colon
+    "E501",  # Line too long
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/{tests,docs,examples}/*" = ["D1"]  # Don't require any docstrings in these directories
 
 [tool.ruff.lint.isort]
 known-first-party = ["torchpme"]

--- a/src/torchpme/calculators/calculator.py
+++ b/src/torchpme/calculators/calculator.py
@@ -73,7 +73,6 @@ class Calculator(torch.nn.Module):
             len(charges))``, where If the inputs are only single tensors only a single
             torch tensor with the potentials is returned.
         """
-
         # Compute the pair potential terms V(r_ij) for each pair of atoms (i,j)
         # contained in the neighbor list
         with profiler.record_function("compute bare potential"):

--- a/src/torchpme/calculators/ewald.py
+++ b/src/torchpme/calculators/ewald.py
@@ -6,7 +6,8 @@ from .calculator import Calculator
 
 
 class EwaldCalculator(Calculator):
-    r"""Potential computed using the Ewald sum.
+    r"""
+    Potential computed using the Ewald sum.
 
     Scaling as :math:`\mathcal{O}(N^2)` with respect to the number of particles
     :math:`N`.

--- a/src/torchpme/calculators/pme.py
+++ b/src/torchpme/calculators/pme.py
@@ -9,7 +9,8 @@ from .calculator import Calculator
 
 
 class PMECalculator(Calculator):
-    r"""Potential using a particle mesh-based Ewald (PME).
+    r"""
+    Potential using a particle mesh-based Ewald (PME).
 
     Scaling as :math:`\mathcal{O}(NlogN)` with respect to the number of particles
     :math:`N` used as a reference to test faster implementations.

--- a/src/torchpme/lib/kspace_filter.py
+++ b/src/torchpme/lib/kspace_filter.py
@@ -103,7 +103,8 @@ class KSpaceFilter(torch.nn.Module):
         cell: Optional[torch.Tensor] = None,
         ns_mesh: Optional[torch.Tensor] = None,
     ) -> None:
-        """Update buffers and derived attributes of the instance.
+        """
+        Update buffers and derived attributes of the instance.
 
         If neither ``cell`` nor ``ns_mesh`` are passed, only the filter is updated,
         typically following a change in the underlying potential. If ``cell`` and/or

--- a/src/torchpme/lib/kvectors.py
+++ b/src/torchpme/lib/kvectors.py
@@ -14,7 +14,6 @@ def get_ns_mesh(cell: torch.Tensor, mesh_spacing: float):
 
     :return: torch.tensor of length 3 containing the mesh size
     """
-
     basis_norms = torch.linalg.norm(cell, dim=1)
     ns_approx = basis_norms / mesh_spacing
     ns_actual_approx = 2 * ns_approx + 1  # actual number of mesh points

--- a/src/torchpme/lib/mesh_interpolator.py
+++ b/src/torchpme/lib/mesh_interpolator.py
@@ -72,7 +72,8 @@ class MeshInterpolator(torch.nn.Module):
         cell: Optional[torch.Tensor] = None,
         ns_mesh: Optional[torch.Tensor] = None,
     ) -> None:
-        """Update buffers and derived attributes of the instance.
+        """
+        Update buffers and derived attributes of the instance.
 
         Call this to reuse a ``MeshInterpolator`` object when the ``cell`` parameters or
         the mesh resolution changes. If neither ``cell`` nor ``ns_mesh`` are passed
@@ -83,7 +84,6 @@ class MeshInterpolator(torch.nn.Module):
         :param ns_mesh: toch.tensor of shape ``(3,)`` Number of mesh points to use along
             each of the three axes
         """
-
         if cell is not None:
             if cell.shape != (3, 3):
                 raise ValueError(

--- a/src/torchpme/metatensor/calculator.py
+++ b/src/torchpme/metatensor/calculator.py
@@ -15,7 +15,8 @@ from ..potentials.spline import Potential
 
 
 class Calculator(torch.nn.Module):
-    """Base calculator for the metatensor interface.
+    """
+    Base calculator for the metatensor interface.
 
     This is just a thin wrapper around the corresponding
     generic torch :class:`torchpme.calculators.Calculator`.
@@ -157,7 +158,6 @@ class Calculator(torch.nn.Module):
 
         :return: TensorMap containing the potential of all types.
         """
-
         self._validate_compute_parameters(system, neighbors)
 
         # In actual computations, the data type (dtype) and device (e.g. CPU, GPU) of

--- a/src/torchpme/potentials/combined.py
+++ b/src/torchpme/potentials/combined.py
@@ -6,7 +6,8 @@ from .potential import Potential
 
 
 class CombinedPotential(Potential):
-    """A potential that is a linear combination of multiple potentials.
+    """
+    A potential that is a linear combination of multiple potentials.
 
     A class representing a combined potential that aggregates multiple individual
     potentials with weights for use in long-range (LR) and short-range (SR)

--- a/src/torchpme/potentials/coulomb.py
+++ b/src/torchpme/potentials/coulomb.py
@@ -6,7 +6,8 @@ from .potential import Potential
 
 
 class CoulombPotential(Potential):
-    """Smoothed electrostatic Coulomb potential :math:`1/r`.
+    """
+    Smoothed electrostatic Coulomb potential :math:`1/r`.
 
     Here :math:`r` is the inter-particle distance
 
@@ -71,7 +72,6 @@ class CoulombPotential(Potential):
         :param dist: torch.tensor containing the distances at which the potential is to
             be evaluated.
         """
-
         if self.smearing is None:
             raise ValueError(
                 "Cannot compute long-range contribution without specifying `smearing`."
@@ -86,7 +86,6 @@ class CoulombPotential(Potential):
         :param k_sq: torch.tensor containing the squared lengths (2-norms) of the wave
             vectors k at which the Fourier-transformed potential is to be evaluated
         """
-
         # The k=0 term often needs to be set separately since for exponents p<=3
         # dimension, there is a divergence to +infinity. Setting this value manually
         # to zero physically corresponds to the addition of a uniform background charge

--- a/src/torchpme/potentials/inversepowerlaw.py
+++ b/src/torchpme/potentials/inversepowerlaw.py
@@ -6,15 +6,20 @@ from torch.special import gammainc, gammaincc, gammaln
 from .potential import Potential
 
 
-# since pytorch has implemented the incomplete Gamma functions, but not the much more
-# commonly used (complete) Gamma function, we define it in a custom way to make autograd
-# work as in https://discuss.pytorch.org/t/is-there-a-gamma-function-in-pytorch/17122
 def gamma(x: torch.Tensor) -> torch.Tensor:
+    """
+    (Complete) Gamma function.
+
+    pytorch has not implemented the commonly used (complete) Gamma function. We define
+    it in a custom way to make autograd work as in
+    https://discuss.pytorch.org/t/is-there-a-gamma-function-in-pytorch/17122
+    """
     return torch.exp(gammaln(x))
 
 
 class InversePowerLawPotential(Potential):
-    """Inverse power-law potentials of the form :math:`1/r^p`.
+    """
+    Inverse power-law potentials of the form :math:`1/r^p`.
 
     Here :math:`r` is a distance parameter and :math:`p` an exponent.
 
@@ -87,7 +92,6 @@ class InversePowerLawPotential(Potential):
         :param dist: torch.tensor containing the distances at which the potential is to
             be evaluated.
         """
-
         if self.smearing is None:
             raise ValueError(
                 "Cannot compute long-range contribution without specifying `smearing`."
@@ -103,7 +107,8 @@ class InversePowerLawPotential(Potential):
 
     @torch.jit.export
     def lr_from_k_sq(self, k_sq: torch.Tensor) -> torch.Tensor:
-        """Fourier transform of the LR part potential in terms of :math:`k^2`.
+        """
+        Fourier transform of the LR part potential in terms of :math:`k^2`.
 
         If only the Coulomb potential is needed, the last line can be
         replaced by

--- a/src/torchpme/potentials/potential.py
+++ b/src/torchpme/potentials/potential.py
@@ -4,7 +4,8 @@ import torch
 
 
 class Potential(torch.nn.Module):
-    r"""Base class defining the interface for a pair potential energy function
+    r"""
+    Base class defining the interface for a pair potential energy function
 
     The class provides the interface to compute a short-range and long-range functions
     in real space (such that :math:`V(r)=V_{\mathrm{SR}}(r)+V_{\mathrm{LR}}(r)` ), as
@@ -69,7 +70,6 @@ class Potential(torch.nn.Module):
         :param dist: a torc.Tensor containing the interatomic distances over which the
             cutoff function should be computed.
         """
-
         if self.exclusion_radius is None:
             raise ValueError(
                 "Cannot compute cutoff function when `exclusion_radius` is not set"
@@ -83,19 +83,20 @@ class Potential(torch.nn.Module):
 
     @torch.jit.export
     def from_dist(self, dist: torch.Tensor) -> torch.Tensor:
-        """Computes a pair potential given a tensor of interatomic distances.
+        """
+        Computes a pair potential given a tensor of interatomic distances.
 
         :param dist: torch.Tensor containing the distances at which the potential
             is to be evaluated.
         """
-
         raise NotImplementedError(
             f"from_dist is not implemented for {self.__class__.__name__}"
         )
 
     @torch.jit.export
     def sr_from_dist(self, dist: torch.Tensor) -> torch.Tensor:
-        r"""Short-range part of the pair potential in real space.
+        r"""
+        Short-range part of the pair potential in real space.
 
         Even though one can provide a custom version, this is usually evaluated as
         :math:`V_{\mathrm{SR}}(r)=V(r)-V_{\mathrm{LR}}(r)`, based on the full and
@@ -108,7 +109,6 @@ class Potential(torch.nn.Module):
         :param dist: torch.tensor containing the distances at which the potential is to
             be evaluated.
         """
-
         if self.smearing is None:
             raise ValueError(
                 "Cannot compute range-separated potential when `smearing` is not specified."
@@ -126,7 +126,6 @@ class Potential(torch.nn.Module):
         :param dist: torch.tensor containing the distances at which the potential is to
             be evaluated.
         """
-
         raise NotImplementedError(
             f"lr_from_dist is not implemented for {self.__class__.__name__}"
         )
@@ -152,7 +151,6 @@ class Potential(torch.nn.Module):
         Compatibility function with the interface of :class:`KSpaceKernel`, so that
         potentials can be used as kernels for :class:`KSpaceFilter`.
         """
-
         return self.lr_from_k_sq(k_sq)
 
     @torch.jit.export

--- a/src/torchpme/potentials/spline.py
+++ b/src/torchpme/potentials/spline.py
@@ -12,7 +12,8 @@ from .potential import Potential
 
 
 class SplinePotential(Potential):
-    r"""Potential built from a spline interpolation.
+    r"""
+    Potential built from a spline interpolation.
 
     The potential is assumed to have only a long-range part, but one can also
     add a short-range part if needed, by inheriting and redefining
@@ -121,12 +122,12 @@ class SplinePotential(Potential):
         return self.lr_from_dist(dist) + self.sr_from_dist(dist)
 
     def sr_from_dist(self, dist: torch.Tensor) -> torch.Tensor:
-        """Short-range part of the range-separated potential.
+        """
+        Short-range part of the range-separated potential.
 
         :param dist: torch.tensor containing the distances at which the potential is to
             be evaluated.
         """
-
         return 0.0 * dist
 
     def lr_from_dist(self, dist: torch.Tensor) -> torch.Tensor:

--- a/src/torchpme/utils/splines.py
+++ b/src/torchpme/utils/splines.py
@@ -4,7 +4,8 @@ import torch
 
 
 class CubicSpline(torch.nn.Module):
-    r"""Cubic spline calculator.
+    r"""
+    Cubic spline calculator.
 
     Class implementing a cubic spline for a real-valued function.
 
@@ -42,7 +43,8 @@ class CubicSpline(torch.nn.Module):
 
 
 class CubicSplineReciprocal(torch.nn.Module):
-    r"""Reciprocal-axis cubic spline calculator.
+    r"""
+    Reciprocal-axis cubic spline calculator.
 
     Computes a spline on a :math:`1/x` grid, "extending" it so that
     it converges smoothly to zero as :math:`x\rightarrow\infty`.
@@ -115,14 +117,14 @@ class CubicSplineReciprocal(torch.nn.Module):
 
 
 def _solve_tridiagonal(a, b, c, d):
-    """Helper function to solve a tri-diagonal linear problem.
+    """
+    Helper function to solve a tri-diagonal linear problem.
 
     a = torch.zeros(n)  # Sub-diagonal (a[1..n-1])
     b = torch.zeros(n)  # Main diagonal (b[0..n-1])
     c = torch.zeros(n)  # Super-diagonal (c[0..n-2])
     d = torch.zeros(n)  # Right-hand side (d[0..n-1])
     """
-
     n = len(d)
     # Create copies to avoid modifying the original arrays
     c_prime = torch.zeros(n)
@@ -151,7 +153,8 @@ def compute_second_derivatives(
     y_points: torch.Tensor,
     high_precision: Optional[bool] = True,
 ):
-    """Computes second derivatives given the grid points of a cubic spline.
+    """
+    Computes second derivatives given the grid points of a cubic spline.
 
     :param x_points: Abscissas of the splining points for the real-space function
     :param y_points: Ordinates of the splining points for the real-space function
@@ -159,7 +162,6 @@ def compute_second_derivatives(
 
     :return: The second derivatives for the spline points
     """
-
     # Do the calculation in float64 if required
     x = x_points
     y = y_points
@@ -206,7 +208,8 @@ def compute_spline_ft(
     d2y_points: torch.Tensor,
     high_precision: Optional[bool] = True,
 ):
-    r"""Computes the Fourier transform of a splined radial function.
+    r"""
+    Computes the Fourier transform of a splined radial function.
 
     Evaluates the integral
 

--- a/src/torchpme/utils/tuning.py
+++ b/src/torchpme/utils/tuning.py
@@ -155,7 +155,6 @@ def tune_ewald(
     0.1
 
     """
-
     _validate_parameters(sum_squared_charges, cell, positions, exponent)
 
     if not isinstance(accuracy, float):
@@ -183,9 +182,11 @@ def tune_ewald(
     volume = torch.abs(cell.det())
 
     def smooth_lr_wavelength(lr_wavelength):
-        """Confine to (0, min_dimension), ensuring that the ``ns``
+        """
+        Confine to (0, min_dimension), ensuring that the ``ns``
         parameter is not smaller than 1
-        (see :func:`_compute_lr` of :class:`CalculatorEwald`)."""
+        (see :func:`_compute_lr` of :class:`CalculatorEwald`).
+        """
         return min_dimension * torch.sigmoid(lr_wavelength)
 
     def err_Fourier(smearing, lr_wavelength):
@@ -260,7 +261,8 @@ def tune_pme(
     learning_rate: float = 5e-3,
     verbose: bool = False,
 ):
-    r"""Find the optimal parameters for :class:`torchpme.PMECalculator`.
+    r"""
+    Find the optimal parameters for :class:`torchpme.PMECalculator`.
 
     For the error formulas are given `elsewhere <https://doi.org/10.1063/1.470043>`_.
     Note the difference notation between the parameters in the reference and ours:
@@ -353,7 +355,6 @@ def tune_pme(
     0.1
 
     """
-
     _validate_parameters(sum_squared_charges, cell, positions, exponent)
 
     if not isinstance(accuracy, float):
@@ -380,9 +381,11 @@ def tune_pme(
     volume = torch.abs(cell.det())
 
     def smooth_mesh_spacing(mesh_spacing):
-        """Confine to (0, min_dimension), ensuring that the ``ns``
+        """
+        Confine to (0, min_dimension), ensuring that the ``ns``
         parameter is not smaller than 1
-        (see :func:`_compute_lr` of :class:`PMEPotential`)."""
+        (see :func:`_compute_lr` of :class:`PMEPotential`).
+        """
         return min_dimension * torch.sigmoid(mesh_spacing)
 
     def err_Fourier(smearing, mesh_spacing):
@@ -579,7 +582,6 @@ def _compute_RMS_phi(
 
 def _get_ns_mesh_differentiable(cell: torch.Tensor, mesh_spacing: float):
     """differentiable version of :func:`get_ns_mesh`"""
-
     basis_norms = torch.linalg.norm(cell, dim=1)
     ns_approx = basis_norms / mesh_spacing
     ns_actual_approx = 2 * ns_approx + 1  # actual number of mesh points

--- a/tests/calculators/test_workflow.py
+++ b/tests/calculators/test_workflow.py
@@ -1,5 +1,7 @@
-"""Basic tests if the calculator works and is torch scriptable. Actual tests are done
-for the metatensor calculator."""
+"""
+Basic tests if the calculator works and is torch scriptable. Actual tests are done
+for the metatensor calculator.
+"""
 
 import io
 import math

--- a/tests/lib/test_kspace_filter.py
+++ b/tests/lib/test_kspace_filter.py
@@ -1,6 +1,4 @@
-"""
-Tests for `kspace_filter` classes
-"""
+"""Tests for `kspace_filter` classes"""
 
 import pytest
 import torch

--- a/tests/lib/test_mesh_interpolator.py
+++ b/tests/lib/test_mesh_interpolator.py
@@ -1,6 +1,4 @@
-"""
-Tests for mesh interpolator class
-"""
+"""Tests for mesh interpolator class"""
 
 import pytest
 import torch
@@ -10,9 +8,7 @@ from torchpme.lib import MeshInterpolator
 
 
 class TestMeshInterpolatorForward:
-    """
-    Tests for the "points_to_mesh" function of the MeshInterpolator class
-    """
+    """Tests for the "points_to_mesh" function of the MeshInterpolator class"""
 
     # Define parameters that are common to all tests
     interpolation_nodes_P3M = [1, 2, 3, 4, 5]
@@ -200,9 +196,7 @@ class TestMeshInterpolatorBackward:
 
     @pytest.mark.parametrize("n_mesh", torch.arange(18, 31))
     def test_exact_invertibility_for_interpolation_nodes_two(self, n_mesh):
-        """
-        Test for interpolation interpolation_nodes = 2
-        """
+        """Test for interpolation interpolation_nodes = 2"""
         torch.random.manual_seed(3351285)
         # Define some basic parameteres for this test
         # While we could also loop over these, we are instead varying these
@@ -240,9 +234,7 @@ class TestMeshInterpolatorBackward:
     @pytest.mark.parametrize("random_runs", random_runs)
     @pytest.mark.parametrize("interpolation_nodes", interpolation_nodes)
     def test_total_mass(self, interpolation_nodes, random_runs):
-        """
-        interpolate on all mesh points: should yield same total mass
-        """
+        """interpolate on all mesh points: should yield same total mass"""
         # Define some basic parameteres for this test
         # While we could also loop over these, we are instead varying these
         # parameters across the various tests to reduce the number of calls

--- a/tests/metatensor/test_workflow_metatensor.py
+++ b/tests/metatensor/test_workflow_metatensor.py
@@ -1,6 +1,4 @@
-"""
-Madelung tests
-"""
+"""Madelung tests"""
 
 import io
 

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -66,7 +66,6 @@ def test_sr_lr_split(exponent, smearing):
     whether the sum of the SR and LR parts combine to the standard inverse power-law
     potential.
     """
-
     # Compute diverse potentials for this inverse power law
     ipl = InversePowerLawPotential(exponent=exponent, smearing=smearing, dtype=dtype)
 
@@ -95,7 +94,6 @@ def test_exact_sr(exponent, smearing):
     distance range (the variable dist_min) is increased, since the potential has a
     (removable) singularity at r=0.
     """
-
     # Compute SR part of Coulomb potential using the potentials class working for any
     # exponent
     ipl = InversePowerLawPotential(exponent=exponent, smearing=smearing, dtype=dtype)
@@ -130,7 +128,6 @@ def test_exact_lr(exponent, smearing):
     distance range (the variable dist_min) is increased, since the potential has a
     (removable) singularity at r=0.
     """
-
     # Compute LR part of Coulomb potential using the potentials class working for any
     # exponent
     ipl = InversePowerLawPotential(exponent=exponent, smearing=smearing, dtype=dtype)
@@ -165,7 +162,6 @@ def test_exact_fourier(exponent, smearing):
     distance range (the variable dist_min) is increased, since the potential has a
     (removable) singularity at r=0.
     """
-
     # Compute LR part of Coulomb potential using the potentials class working for any
     # exponent
     ipl = InversePowerLawPotential(exponent=exponent, smearing=smearing, dtype=dtype)
@@ -291,9 +287,10 @@ def test_f_cutoff(exclusion_radius):
 
 @pytest.mark.parametrize("smearing", smearinges)
 def test_inverserp_coulomb(smearing):
-    """Check that an explicit Coulomb potential
-    matches the 1/r^p implementation with p=1."""
-
+    """
+    Check that an explicit Coulomb potential
+    matches the 1/r^p implementation with p=1.
+    """
     # Compute LR part of Coulomb potential using the potentials class working for any
     # exponent
     ipl = InversePowerLawPotential(exponent=1.0, smearing=smearing, dtype=dtype)
@@ -439,7 +436,6 @@ def test_potentials_jit(potpars):
 
 @pytest.mark.parametrize("smearing", smearinges)
 def test_combined_potential(smearing):
-    """"""
     ipl_1 = InversePowerLawPotential(exponent=1.0, smearing=smearing, dtype=dtype)
     ipl_2 = InversePowerLawPotential(exponent=2.0, smearing=smearing, dtype=dtype)
 

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ package = skip
 deps = ruff
 commands =
     ruff format {[testenv]lint_folders}
-    ruff check --fix-only {[testenv]lint_folders}
+    ruff check --fix-only {[testenv]lint_folders} {posargs}
 
 [testenv:docs]
 description = Building the package documentation.


### PR DESCRIPTION
Since we polished the docs already a bit, I suggesting some auto rules for the format according to PEP257 as implemented in https://docs.astral.sh/ruff/rules/#pydocstyle-d.

I ignored all of the write styling schemes as you can see once reading the `ignore` list. All of the styling rules (new lines/no new lines before/after docstrings) will be applied automatically during formatting. Of course rules for writing docs can't be done by ruff. You still need to ask your LLM for this.

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--96.org.readthedocs.build/en/96/

<!-- readthedocs-preview torch-pme end -->