### PR TITLE
Cut down the number of tests of `test_random_structure`

### DIFF
--- a/tests/calculators/test_values_ewald.py
+++ b/tests/calculators/test_values_ewald.py
@@ -207,8 +207,8 @@ def test_wigner(crystal_name, scaling_factor):
         torch.testing.assert_close(energies, energies_ref, atol=0.0, rtol=4.2e-6)
 
 
-@pytest.mark.parametrize("cutoff", [5.54, 6.01])
-@pytest.mark.parametrize("frame_index", [0, 1, 2])
+@pytest.mark.parametrize("cutoff", [5.54])
+@pytest.mark.parametrize("frame_index", [0, 1])
 @pytest.mark.parametrize("scaling_factor", [0.43, 1.33])
 @pytest.mark.parametrize("ortho", generate_orthogonal_transformations())
 @pytest.mark.parametrize("calc_name", ["ewald", "pme"])


### PR DESCRIPTION
Currently there are many tests under `test_random_structure`, and this will become too time-consuming after the introducing of P3M (#101). Thus, to save the test time, after discussion, we decided to remove the tests on different `cutoff` and reduce the number of frames for test from 3 to 2.

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--107.org.readthedocs.build/en/107/

<!-- readthedocs-preview torch-pme end -->