### PR TITLE
add `_is_range_seperated` parameter

### DIFF
--- a/examples/7-lode-demo.py
+++ b/examples/7-lode-demo.py
@@ -263,7 +263,7 @@ def get_radial_quadrature(order, R):
     return torch.from_numpy(nodes), torch.from_numpy(weights)
 
 
-def get_full_grid(n, R):
+def get_full_grid(n: int, R: float) -> tuple[torch.Tensor, torch.Tensor]:
     lm_nodes, lm_weights = get_theta_phi_quadrature(n)
     r_nodes, r_weights = get_radial_quadrature(n, R)
 
@@ -408,10 +408,10 @@ class LODECalculator(torchpme.Calculator):
 
         cell = torch.eye(3)
         ns = torch.tensor([2, 2, 2])
-        self._MI = torchpme.lib.MeshInterpolator(
+        self._MI: torchpme.lib.MeshInterpolator = torchpme.lib.MeshInterpolator(
             cell=cell, ns_mesh=ns, interpolation_nodes=3, method="P3M"
         )
-        self._KF = torchpme.lib.KSpaceFilter(
+        self._KF: torchpme.lib.KSpaceFilter = torchpme.lib.KSpaceFilter(
             cell=cell,
             ns_mesh=ns,
             kernel=self.potential,
@@ -431,9 +431,9 @@ class LODECalculator(torchpme.Calculator):
             (nodes[:, 1]) / torch.sqrt((weights * nodes[:, 1] ** 2).sum()),  # y
             (nodes[:, 2]) / torch.sqrt((weights * nodes[:, 2] ** 2).sum()),  # z
         ]
-        self._basis = torch.stack(stencils)
-        self._nodes = nodes
-        self._weights = weights
+        self._basis: torch.Tensor = torch.stack(stencils)
+        self._nodes: torch.Tensor = nodes
+        self._weights: torch.Tensor = weights
 
     def forward(
         self,

--- a/examples/8-combined-potential.py
+++ b/examples/8-combined-potential.py
@@ -60,15 +60,12 @@ lr_wavelength = 0.5 * smearing
 # %%
 #
 # We now construct the potential as sum of two :class:`InversePowerLawPotential` using
-# :class:`CombinedPotential`. The presence of a numerical `smearing` value is used as an
-# indication that the potential can compute the terms needed for range-separated
-# evaluation, and so one has to set it also for the combined potential, even if it is
-# not used explicitly in the evaluation of the combination.
+# :class:`CombinedPotential`.
 
 pot_1 = InversePowerLawPotential(exponent=1.0, smearing=smearing)
 pot_2 = InversePowerLawPotential(exponent=2.0, smearing=smearing)
 
-potential = CombinedPotential(potentials=[pot_1, pot_2], smearing=smearing)
+potential = CombinedPotential(potentials=[pot_1, pot_2])
 
 # Note also that :class:`CombinedPotential` can be used with any combination of
 # potentials, as long they are all either direct or range separated. For instance, one

--- a/src/torchpme/calculators/ewald.py
+++ b/src/torchpme/calculators/ewald.py
@@ -67,7 +67,7 @@ class EwaldCalculator(Calculator):
             full_neighbor_list=full_neighbor_list,
             prefactor=prefactor,
         )
-        if potential.smearing is None:
+        if not potential._is_range_separated:
             raise ValueError(
                 "Must specify range radius to use a potential with EwaldCalculator"
             )

--- a/src/torchpme/calculators/pme.py
+++ b/src/torchpme/calculators/pme.py
@@ -61,7 +61,7 @@ class PMECalculator(Calculator):
             prefactor=prefactor,
         )
 
-        if potential.smearing is None:
+        if not potential._is_range_separated:
             raise ValueError(
                 "Must specify smearing to use a potential with EwaldCalculator"
             )

--- a/src/torchpme/potentials/coulomb.py
+++ b/src/torchpme/potentials/coulomb.py
@@ -72,7 +72,7 @@ class CoulombPotential(Potential):
         :param dist: torch.tensor containing the distances at which the potential is to
             be evaluated.
         """
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute long-range contribution without specifying `smearing`."
             )
@@ -86,7 +86,7 @@ class CoulombPotential(Potential):
         :param kvectors: torch.tensor containing the wave vectors k at which the
             Fourier-transformed potential is to be evaluated
         """
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute long-range kernel without specifying `smearing`."
             )
@@ -104,7 +104,7 @@ class CoulombPotential(Potential):
 
     def self_contribution(self) -> torch.Tensor:
         # self-correction for 1/r potential
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute self contribution without specifying `smearing`."
             )
@@ -112,7 +112,7 @@ class CoulombPotential(Potential):
 
     def background_correction(self) -> torch.Tensor:
         # "charge neutrality" correction for 1/r potential
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute background correction without specifying `smearing`."
             )

--- a/src/torchpme/potentials/inversepowerlaw.py
+++ b/src/torchpme/potentials/inversepowerlaw.py
@@ -92,11 +92,10 @@ class InversePowerLawPotential(Potential):
         :param dist: torch.tensor containing the distances at which the potential is to
             be evaluated.
         """
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute long-range contribution without specifying `smearing`."
             )
-
         exponent = self.exponent
         smearing = self.smearing
 
@@ -113,7 +112,7 @@ class InversePowerLawPotential(Potential):
         :param kvectors: torch.tensor containing the wave vectors k at which the
             Fourier-transformed potential is to be evaluated
         """
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute long-range kernel without specifying `smearing`."
             )
@@ -143,7 +142,7 @@ class InversePowerLawPotential(Potential):
 
     def self_contribution(self) -> torch.Tensor:
         # self-correction for 1/r^p potential
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute self contribution without specifying `smearing`."
             )
@@ -152,7 +151,7 @@ class InversePowerLawPotential(Potential):
 
     def background_correction(self) -> torch.Tensor:
         # "charge neutrality" correction for 1/r^p potential
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute background correction without specifying `smearing`."
             )

--- a/src/torchpme/potentials/potential.py
+++ b/src/torchpme/potentials/potential.py
@@ -46,12 +46,18 @@ class Potential(torch.nn.Module):
             dtype = torch.get_default_dtype()
         if device is None:
             device = torch.device("cpu")
+
+        if smearing is None:
+            self._is_range_separated = False
+            self.register_buffer(
+                "smearing", torch.tensor(1.0, device=device, dtype=dtype)
+            )
         if smearing is not None:
+            self._is_range_separated = True
             self.register_buffer(
                 "smearing", torch.tensor(smearing, device=device, dtype=dtype)
             )
-        else:
-            self.smearing = None
+
         if exclusion_radius is not None:
             self.register_buffer(
                 "exclusion_radius",
@@ -109,7 +115,7 @@ class Potential(torch.nn.Module):
         :param dist: torch.tensor containing the distances at which the potential is to
             be evaluated.
         """
-        if self.smearing is None:
+        if not self._is_range_separated:
             raise ValueError(
                 "Cannot compute range-separated potential when `smearing` is not specified."
             )


### PR DESCRIPTION
This is a better way to set the status if a potential is range separated or not. This change does not change anything for the users but allows the removal of passing the unused `smearing` parameter when using a `CombinedPotential`.

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--109.org.readthedocs.build/en/109/

<!-- readthedocs-preview torch-pme end -->