### PR TITLE
Use setuptools-scm to control version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -47,6 +49,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 *DS_Store
 *coverage*
 sg_execution_times.rst
+_version.py
 *.gz
 
 .tox/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -128,20 +128,16 @@ How to Perform a Release
    - Ensure that all `CI tests <https://github.com/lab-cosmo/torch-pme/actions>`_ pass.
    - Optionally, run the tests locally to double-check.
 
-2. **Update the Version String**
-
-   - Update the `__version__` string in ``__init__.py`` to reflect the new version, e.g.,
-     `0.1.1` for a stable release or `0.1.1rc1` for a release candidate.
-
-3. **Update the Changelog**
+2. **Update the Changelog**
 
    - Edit the changelog located in ``docs/src/references/changelog.rst``:
-     - Add a new section for the current version, summarizing the changes.
+     - Add a new section for the new version, summarizing the changes.
      - Leave a placeholder section titled *Unreleased* for future updates.
 
-4. **Merge the PR and Create a Tag**
+3. **Merge the PR and Create a Tag**
 
-   - After the release PR is merged, create a Git tag and push it to GitHub:
+   - After the release PR is merged, create a Git tag and push it to GitHub. For example
+     for a release of version ``0.1.1``:
 
      .. code-block:: bash
 
@@ -149,9 +145,9 @@ How to Perform a Release
         git push origin --tags
 
    - For a release candidate, the tag should include an additional dash, e.g.,
-     `v0.1.1-rc1`.
+     ``v0.1.1-rc1``.
 
-5. **Finalize the GitHub Release**
+4. **Finalize the GitHub Release**
 
    - Once the PR is merged, the CI will automatically:
      - Publish the package to PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
-requires = [
-    "setuptools",
-    "wheel",
-]
+requires = ["setuptools", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -66,6 +63,9 @@ repository = "https://github.com/lab-cosmo/torch-pme"
 issues = "https://github.com/lab-cosmo/torch-pme/issues"
 changelog = "https://lab-cosmo.github.io/torch-pme/latest/references/changelog.html"
 
+[tool.check-manifest]
+ignore = ["src/torchpme/_version.py"]
+
 [tool.coverage.report]
 show_missing = true
 include = ["src/torchpme/*"]
@@ -78,7 +78,7 @@ data_file = 'tests/.coverage'
 output = 'tests/coverage.xml'
 
 [tool.ruff]
-exclude = ["docs/src/examples/**"]
+exclude = ["docs/src/examples/**", "src/torchpme/_version.py"]
 line-length = 88
 
 [tool.ruff.lint]
@@ -123,6 +123,9 @@ known-first-party = ["torchpme"]
 [tool.ruff.format]
 docstring-code-format = true
 
+[tool.setuptools_scm]
+version_file = "src/torchpme/_version.py"
+
 [tool.mypy]
 exclude = ["docs/src/examples"]
 follow_imports = 'skip'
@@ -141,6 +144,3 @@ filterwarnings = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-[tool.setuptools.dynamic]
-version = {attr = "torchpme.__version__"}

--- a/src/torchpme/__init__.py
+++ b/src/torchpme/__init__.py
@@ -1,6 +1,7 @@
 import contextlib
 
 from . import calculators, lib, potentials, utils  # noqa
+from ._version import __version__, __version_tuple__  # noqa
 from .calculators import Calculator, EwaldCalculator, P3MCalculator, PMECalculator
 from .potentials import (
     CombinedPotential,
@@ -24,4 +25,3 @@ __all__ = [
     "SplinePotential",
     "CombinedPotential",
 ]
-__version__ = "0.1.0"


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Use [setuptools-scm](https://pypi.org/project/setuptools-scm/) to automatically create the version string based on git tag. For example for the current PR this would be

```
torch-pme-0.1.1.dev3+g2f000d0
```

using these systems makes comparisons between developer version easier.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--125.org.readthedocs.build/en/125/

<!-- readthedocs-preview torch-pme end -->