### PR TITLE
check for zero cell

### DIFF
--- a/docs/extensions/versions_list.py
+++ b/docs/extensions/versions_list.py
@@ -2,7 +2,6 @@ import docutils
 from packaging.version import parse as version_parse
 from sphinx.util.docutils import SphinxDirective
 
-
 DOC_ROOT = "https://lab-cosmo.github.io/torch-pme"
 
 

--- a/docs/src/references/changelog.rst
+++ b/docs/src/references/changelog.rst
@@ -34,7 +34,7 @@ Added
 Fixed
 #####
 
-* ``_validate_compute_parameters`` now checks if the cell is zero if the potential is range-separated
+* All calculators now check if the cell is zero if the potential is range-separated
 
 .. Changed
 .. #######

--- a/docs/src/references/changelog.rst
+++ b/docs/src/references/changelog.rst
@@ -31,8 +31,10 @@ Added
 
 * First release outside of the lab.
 
-.. Fixed
-.. #####
+Fixed
+#####
+
+* ``_validate_compute_parameters`` now checks if the cell is zero if the potential is range-separated
 
 .. Changed
 .. #######

--- a/src/torchpme/calculators/calculator.py
+++ b/src/torchpme/calculators/calculator.py
@@ -219,10 +219,8 @@ class Calculator(torch.nn.Module):
                 f"({device})"
             )
 
-        determinant = torch.linalg.det(cell)
-
-        if smearing is not None and torch.isclose(
-            determinant, torch.tensor(0.0, dtype=cell.dtype, device=cell.device)
+        if smearing is not None and torch.equal(
+            cell.det(), torch.tensor(0.0, dtype=cell.dtype, device=cell.device)
         ):
             raise ValueError(
                 "provided `cell` has a determinant of 0 and therefore is not valid for "

--- a/src/torchpme/calculators/calculator.py
+++ b/src/torchpme/calculators/calculator.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 from torch import profiler
 
@@ -158,6 +160,7 @@ class Calculator(torch.nn.Module):
             positions=positions,
             neighbor_indices=neighbor_indices,
             neighbor_distances=neighbor_distances,
+            smearing=self.potential.smearing,
         )
 
         # Compute short-range (SR) part using a real space sum
@@ -185,6 +188,7 @@ class Calculator(torch.nn.Module):
         positions: torch.Tensor,
         neighbor_indices: torch.Tensor,
         neighbor_distances: torch.Tensor,
+        smearing: Optional[float],
     ) -> None:
         device = positions.device
         dtype = positions.dtype
@@ -213,6 +217,16 @@ class Calculator(torch.nn.Module):
             raise ValueError(
                 f"device of `cell` ({cell.device}) must be same as `positions` "
                 f"({device})"
+            )
+
+        determinant = torch.linalg.det(cell)
+
+        if smearing is not None and torch.isclose(
+            determinant, torch.tensor(0.0, dtype=cell.dtype, device=cell.device)
+        ):
+            raise ValueError(
+                "provided `cell` has a determinant of 0 and therefore is not valid for "
+                "periodic calculation"
             )
 
         # check shape, dtype & device of `charges`

--- a/tests/calculators/test_calculator.py
+++ b/tests/calculators/test_calculator.py
@@ -105,6 +105,24 @@ def test_invalid_device_cell():
         )
 
 
+def test_zero_cell():
+    calculator = Calculator(
+        potential=CoulombPotential(smearing=1, exclusion_radius=None)
+    )
+    match = (
+        r"provided `cell` has a determinant of 0 and therefore is not valid for "
+        r"periodic calculation"
+    )
+    with pytest.raises(ValueError, match=match):
+        calculator.forward(
+            positions=POSITIONS_1,
+            charges=CHARGES_1,
+            cell=torch.zeros([3, 3], dtype=DTYPE, device=DEVICE),
+            neighbor_indices=NEIGHBOR_INDICES,
+            neighbor_distances=NEIGHBOR_DISTANCES,
+        )
+
+
 # Tests for invalid shape, dtype and device of charges
 def test_invalid_dim_charges():
     calculator = CalculatorTest()


### PR DESCRIPTION
Checks if the cell is zero if the given potential is range-separated (i.e. `smearing = None`) as discussed in #115 



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--131.org.readthedocs.build/en/131/

<!-- readthedocs-preview torch-pme end -->