### PR TITLE
Fix inconsistent `cutoff` in neighbor list example

### DIFF
--- a/docs/src/references/changelog.rst
+++ b/docs/src/references/changelog.rst
@@ -27,6 +27,7 @@ changelog <https://keepachangelog.com/en/1.1.0/>`_ format. This project follows
 Fixed
 #####
 
+* Fix inconsistent ``cutoff`` in neighbor list example
 * All calculators now check if the cell is zero if the potential is range-separated
 
 

--- a/examples/2-neighbor-lists-usage.py
+++ b/examples/2-neighbor-lists-usage.py
@@ -224,7 +224,7 @@ positions_new.requires_grad = True
 #
 # and create new distances in a similar manner as above.
 
-nl = vesin.torch.NeighborList(cutoff=1.0, full_list=False)
+nl = vesin.torch.NeighborList(cutoff=cutoff, full_list=False)
 neighbor_indices_new, d = nl.compute(
     points=positions_new, box=cell, periodic=True, quantities="Pd"
 )


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Fixes #134 

The cutoff between the `normal` and vesin torch version in the example was inconsistent. 

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--136.org.readthedocs.build/en/136/

<!-- readthedocs-preview torch-pme end -->