### PR TITLE
Erase dtype and device

### DIFF
--- a/docs/src/references/changelog.rst
+++ b/docs/src/references/changelog.rst
@@ -27,20 +27,13 @@ changelog <https://keepachangelog.com/en/1.1.0/>`_ format. This project follows
 Added
 #####
 
-* Enhanced ``device`` and ``dtype`` consistency checks throughout the library
 * Better documentation for for ``cell``, ``charges`` and ``positions`` parameters
-* Require consistent ``dtype`` between ``positions`` and ``neighbor_distances`` in
-  ``Calculator`` classes and tuning functions.
 
-Changed
+Removed
 #######
 
-* Remove ``device`` and ``dtype`` from init of ``Calculator`` and ``Potential`` classes
-
-Fixed
-#####
-
-* Fix ``device`` and ``dtype`` not being used in the init of the ``P3MCalculator``
+* Remove ``device`` and ``dtype`` from init of ``Calculator``, ``Potential`` and
+  ``Tuning`` classes
 
 `Version 0.2.0 <https://github.com/lab-cosmo/torch-pme/releases/tag/v0.2.0>`_ - 2025-01-23
 ------------------------------------------------------------------------------------------

--- a/docs/src/references/changelog.rst
+++ b/docs/src/references/changelog.rst
@@ -32,6 +32,11 @@ Added
 * Require consistent ``dtype`` between ``positions`` and ``neighbor_distances`` in
   ``Calculator`` classes and tuning functions.
 
+Changed
+#######
+
+* Remove ``device`` and ``dtype`` from init of ``Calculator`` and ``Potential`` classes
+
 Fixed
 #####
 

--- a/examples/01-charges-example.py
+++ b/examples/01-charges-example.py
@@ -73,7 +73,6 @@ smearing, pme_params, _ = tune_pme(
     cutoff=cutoff,
     neighbor_indices=neighbor_indices,
     neighbor_distances=neighbor_distances,
-    dtype=dtype,
 )
 
 # %%
@@ -103,9 +102,9 @@ neighbor_indices, S, D, neighbor_distances = nl.compute(
 # will be used to *compute* the potential energy of the system.
 
 calculator = torchpme.PMECalculator(
-    torchpme.CoulombPotential(smearing=smearing, dtype=dtype), dtype=dtype, **pme_params
+    torchpme.CoulombPotential(smearing=smearing), **pme_params
 )
-
+calculator.to(dtype=dtype)
 # %%
 #
 # Single Charge Channel
@@ -207,9 +206,9 @@ print(charge_Na * potential_one_hot[0] + charge_Cl * potential_one_hot[1])
 # creating a new calculator with the metatensor interface.
 
 calculator_metatensor = torchpme.metatensor.PMECalculator(
-    torchpme.CoulombPotential(smearing=smearing, dtype=dtype), dtype=dtype, **pme_params
+    torchpme.CoulombPotential(smearing=smearing), **pme_params
 )
-
+calculator_metatensor.to(dtype=dtype)
 # %%
 #
 # Computation with metatensor involves using Metatensor's :class:`System

--- a/examples/02-neighbor-lists-usage.py
+++ b/examples/02-neighbor-lists-usage.py
@@ -110,7 +110,6 @@ smearing, pme_params, _ = tune_pme(
     cutoff=cutoff,
     neighbor_indices=neighbor_indices,
     neighbor_distances=neighbor_distances,
-    dtype=dtype,
 )
 
 # %%
@@ -195,8 +194,7 @@ neighbor_distances = distances(
 # compute the potential.
 
 pme = torchpme.PMECalculator(
-    potential=torchpme.CoulombPotential(smearing=smearing, dtype=dtype),
-    dtype=dtype,
+    potential=torchpme.CoulombPotential(smearing=smearing),
     **pme_params,
 )
 potential = pme(

--- a/examples/07-lode-demo.py
+++ b/examples/07-lode-demo.py
@@ -420,7 +420,7 @@ class LODECalculator(torchpme.Calculator):
         )
 
         # assumes a smooth exclusion region so sets the integration cutoff to half that
-        nodes, weights = get_full_grid(n_grid, potential.exclusion_radius.item() / 2)
+        nodes, weights = get_full_grid(n_grid, potential.exclusion_radius / 2)
 
         # these are the "stencils" used to project the potential
         # on an atom-centered basis. NB: weights might also be incorporated

--- a/examples/08-combined-potential.py
+++ b/examples/08-combined-potential.py
@@ -67,10 +67,12 @@ lr_wavelength = 0.5 * smearing
 # evaluation, and so one has to set it also for the combined potential, even if it is
 # not used explicitly in the evaluation of the combination.
 
-pot_1 = InversePowerLawPotential(exponent=1, smearing=smearing, dtype=dtype)
-pot_2 = InversePowerLawPotential(exponent=2, smearing=smearing, dtype=dtype)
-
-potential = CombinedPotential(potentials=[pot_1, pot_2], smearing=smearing, dtype=dtype)
+pot_1 = InversePowerLawPotential(exponent=1, smearing=smearing)
+pot_2 = InversePowerLawPotential(exponent=2, smearing=smearing)
+pot_1 = pot_1.to(dtype=dtype)
+pot_2 = pot_2.to(dtype=dtype)
+potential = CombinedPotential(potentials=[pot_1, pot_2], smearing=smearing)
+potential = potential.to(dtype=dtype)
 
 # Note also that :class:`CombinedPotential` can be used with any combination of
 # potentials, as long they are all either direct or range separated. For instance, one
@@ -156,9 +158,9 @@ plt.show()
 # much bigger system.
 
 calculator = EwaldCalculator(
-    potential=potential, lr_wavelength=lr_wavelength, prefactor=eV_A, dtype=dtype
+    potential=potential, lr_wavelength=lr_wavelength, prefactor=eV_A
 )
-
+calculator.to(dtype=dtype)
 
 # %%
 #

--- a/examples/10-tuning.py
+++ b/examples/10-tuning.py
@@ -120,12 +120,10 @@ smearing = 1.0
 pme_params = {"mesh_spacing": 1.0, "interpolation_nodes": 4}
 
 pme = torchpme.PMECalculator(
-    potential=torchpme.CoulombPotential(smearing=smearing, device=device, dtype=dtype),
-    device=device,
-    dtype=dtype,
+    potential=torchpme.CoulombPotential(smearing=smearing),
     **pme_params,  # type: ignore[arg-type]
 )
-
+pme.to(device=device, dtype=dtype)
 # %%
 # Run the calculator
 # ~~~~~~~~~~~~~~~~~~
@@ -170,8 +168,6 @@ timings = TuningTimings(
     neighbor_indices=neighbor_indices,
     neighbor_distances=neighbor_distances,
     run_backward=True,
-    device=device,
-    dtype=dtype,
 )
 estimated_timing = timings(pme)
 
@@ -220,14 +216,11 @@ def timed_madelung(cutoff, smearing, mesh_spacing, interpolation_nodes, device, 
     )
 
     pme = torchpme.PMECalculator(
-        potential=torchpme.CoulombPotential(
-            smearing=smearing, device=device, dtype=dtype
-        ),
+        potential=torchpme.CoulombPotential(smearing=smearing),
         mesh_spacing=mesh_spacing,
         interpolation_nodes=interpolation_nodes,
-        device=device,
-        dtype=dtype,
     )
+    pme.to(device=device, dtype=dtype)
     potential = pme(
         charges=charges,
         cell=cell,
@@ -247,8 +240,6 @@ def timed_madelung(cutoff, smearing, mesh_spacing, interpolation_nodes, device, 
         run_backward=True,
         n_warmup=1,
         n_repeat=4,
-        device=device,
-        dtype=dtype,
     )
     estimated_timing = timings(pme)
     return madelung, estimated_timing
@@ -457,8 +448,6 @@ smearing, parameters, timing = tune_pme(
     cutoff=5.0,
     neighbor_indices=neighbor_indices,
     neighbor_distances=neighbor_distances,
-    device=device,
-    dtype=dtype,
 )
 
 print(
@@ -492,8 +481,6 @@ for cutoff in cutoff_grid:
         cutoff=cutoff,
         neighbor_indices=filter_indices,
         neighbor_distances=filter_distances,
-        device=device,
-        dtype=dtype,
     )
     timings_grid.append(timing)
 

--- a/examples/basic-usage.py
+++ b/examples/basic-usage.py
@@ -146,7 +146,8 @@ lr_wavelength = smearing / 2
 # contains all the necessary functions (such as those defining the short-range and
 # long-range splits) for this potential and makes them useable in the rest of the code.
 
-potential = CoulombPotential(smearing=smearing, device=device, dtype=dtype)
+potential = CoulombPotential(smearing=smearing)
+potential.to(device=device, dtype=dtype)
 
 # %%
 #
@@ -193,10 +194,8 @@ neighbor_indices, neighbor_distances = nl.compute(
 # Since our structure is relatively small, we use the :class:`EwaldCalculator`.
 # We start by the initialization of the class.
 
-calculator = EwaldCalculator(
-    potential=potential, lr_wavelength=lr_wavelength, device=device, dtype=dtype
-)
-
+calculator = EwaldCalculator(potential=potential, lr_wavelength=lr_wavelength)
+calculator.to(device=device, dtype=dtype)
 # %%
 #
 # Compute Energy

--- a/src/torchpme/_utils.py
+++ b/src/torchpme/_utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Union
 
 import torch
 
@@ -11,7 +11,6 @@ def _validate_parameters(
     neighbor_distances: torch.Tensor,
     smearing: Union[float, None],
 ) -> None:
-    
     dtype = positions.dtype
     device = positions.device
 

--- a/src/torchpme/_utils.py
+++ b/src/torchpme/_utils.py
@@ -10,20 +10,10 @@ def _validate_parameters(
     neighbor_indices: torch.Tensor,
     neighbor_distances: torch.Tensor,
     smearing: Union[float, None],
-    dtype: torch.dtype,
-    device: torch.device,
 ) -> None:
-    if positions.dtype != dtype:
-        raise TypeError(
-            f"type of `positions` ({positions.dtype}) must be same as the class "
-            f"type ({dtype})"
-        )
-
-    if positions.device != device:
-        raise ValueError(
-            f"device of `positions` ({positions.device}) must be same as the class "
-            f"device ({device})"
-        )
+    
+    dtype = positions.dtype
+    device = positions.device
 
     # check shape, dtype and device of positions
     num_atoms = len(positions)
@@ -40,14 +30,14 @@ def _validate_parameters(
             f"{list(cell.shape)}"
         )
 
-    if cell.dtype != positions.dtype:
+    if cell.dtype != dtype:
         raise TypeError(
-            f"type of `cell` ({cell.dtype}) must be same as the class ({dtype})"
+            f"type of `cell` ({cell.dtype}) must be same as that of the `positions` class ({dtype})"
         )
 
     if cell.device != device:
         raise ValueError(
-            f"device of `cell` ({cell.device}) must be same as the class ({device})"
+            f"device of `cell` ({cell.device}) must be same as that of the `positions` class ({device})"
         )
 
     if smearing is not None and torch.equal(
@@ -74,14 +64,14 @@ def _validate_parameters(
             f"{len(positions)} atoms"
         )
 
-    if charges.dtype != positions.dtype:
+    if charges.dtype != dtype:
         raise TypeError(
-            f"type of `charges` ({charges.dtype}) must be same as the class ({dtype})"
+            f"type of `charges` ({charges.dtype}) must be same as that of the `positions` class ({dtype})"
         )
 
     if charges.device != device:
         raise ValueError(
-            f"device of `charges` ({charges.device}) must be same as the class "
+            f"device of `charges` ({charges.device}) must be same as that of the `positions` class "
             f"({device})"
         )
 
@@ -96,7 +86,7 @@ def _validate_parameters(
     if neighbor_indices.device != device:
         raise ValueError(
             f"device of `neighbor_indices` ({neighbor_indices.device}) must be "
-            f"same as the class ({device})"
+            f"same as that of the `positions` class ({device})"
         )
 
     if neighbor_distances.shape != neighbor_indices[:, 0].shape:
@@ -109,11 +99,11 @@ def _validate_parameters(
     if neighbor_distances.device != device:
         raise ValueError(
             f"device of `neighbor_distances` ({neighbor_distances.device}) must be "
-            f"same as the class ({device})"
+            f"same as that of the `positions` class ({device})"
         )
 
-    if neighbor_distances.dtype != positions.dtype:
+    if neighbor_distances.dtype != dtype:
         raise TypeError(
             f"type of `neighbor_distances` ({neighbor_distances.dtype}) must be same "
-            f"as the class ({dtype})"
+            f"as that of the `positions` class ({dtype})"
         )

--- a/src/torchpme/_utils.py
+++ b/src/torchpme/_utils.py
@@ -3,21 +3,6 @@ from typing import Optional, Union
 import torch
 
 
-def _get_dtype(dtype: Optional[torch.dtype]) -> torch.dtype:
-    return torch.get_default_dtype() if dtype is None else dtype
-
-
-def _get_device(device: Union[None, str, torch.device]) -> torch.device:
-    new_device = torch.get_default_device() if device is None else torch.device(device)
-
-    # Add default index of 0 to a cuda device to avoid errors when comparing with
-    # devices from tensors
-    if new_device.type == "cuda" and new_device.index is None:
-        new_device = torch.device("cuda:0")
-
-    return new_device
-
-
 def _validate_parameters(
     charges: torch.Tensor,
     cell: torch.Tensor,

--- a/src/torchpme/calculators/calculator.py
+++ b/src/torchpme/calculators/calculator.py
@@ -27,8 +27,6 @@ class Calculator(torch.nn.Module):
         will come from a full (True) or half (False, default) neighbor list.
     :param prefactor: electrostatics prefactor; see :ref:`prefactors` for details and
         common values.
-    :param dtype: type used for the internal buffers and parameters
-    :param device: device used for the internal buffers and parameters
     """
 
     def __init__(

--- a/src/torchpme/calculators/calculator.py
+++ b/src/torchpme/calculators/calculator.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 import torch
 from torch import profiler
 
-from .._utils import _get_device, _get_dtype, _validate_parameters
+from .._utils import _validate_parameters
 from ..potentials import Potential
 
 
@@ -36,8 +36,6 @@ class Calculator(torch.nn.Module):
         potential: Potential,
         full_neighbor_list: bool = False,
         prefactor: float = 1.0,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
         super().__init__()
 
@@ -46,24 +44,8 @@ class Calculator(torch.nn.Module):
                 f"Potential must be an instance of Potential, got {type(potential)}"
             )
 
-        self.device = _get_device(device)
-        self.dtype = _get_dtype(dtype)
-
-        if self.dtype != potential.dtype:
-            raise TypeError(
-                f"dtype of `potential` ({potential.dtype}) must be same as of "
-                f"`calculator` ({self.dtype})"
-            )
-
-        if self.device != potential.device:
-            raise ValueError(
-                f"device of `potential` ({potential.device}) must be same as of "
-                f"`calculator` ({self.device})"
-            )
-
         self.potential = potential
         self.full_neighbor_list = full_neighbor_list
-
         self.prefactor = prefactor
 
     def _compute_rspace(
@@ -164,8 +146,6 @@ class Calculator(torch.nn.Module):
             neighbor_indices=neighbor_indices,
             neighbor_distances=neighbor_distances,
             smearing=self.potential.smearing,
-            dtype=self.dtype,
-            device=self.device,
         )
 
         # Compute short-range (SR) part using a real space sum

--- a/src/torchpme/calculators/calculator.py
+++ b/src/torchpme/calculators/calculator.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import torch
 from torch import profiler
 

--- a/src/torchpme/calculators/ewald.py
+++ b/src/torchpme/calculators/ewald.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import torch
 
 from ..lib import generate_kvectors_for_ewald

--- a/src/torchpme/calculators/ewald.py
+++ b/src/torchpme/calculators/ewald.py
@@ -55,8 +55,6 @@ class EwaldCalculator(Calculator):
         :obj:`False`, a "half" neighbor list is expected.
     :param prefactor: electrostatics prefactor; see :ref:`prefactors` for details and
         common values.
-    :param dtype: type used for the internal buffers and parameters
-    :param device: device used for the internal buffers and parameters
     """
 
     def __init__(
@@ -65,15 +63,11 @@ class EwaldCalculator(Calculator):
         lr_wavelength: float,
         full_neighbor_list: bool = False,
         prefactor: float = 1.0,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
         super().__init__(
             potential=potential,
             full_neighbor_list=full_neighbor_list,
             prefactor=prefactor,
-            dtype=dtype,
-            device=device,
         )
         if potential.smearing is None:
             raise ValueError(

--- a/src/torchpme/calculators/p3m.py
+++ b/src/torchpme/calculators/p3m.py
@@ -66,9 +66,12 @@ class P3MCalculator(PMECalculator):
             prefactor=prefactor,
         )
 
+        cell = torch.eye(3, device=self.potential.smearing.device, dtype=self.potential.smearing.dtype)
+        ns_mesh = torch.ones(3, dtype=int, device=cell.device)
+
         self.kspace_filter: P3MKSpaceFilter = P3MKSpaceFilter(
-            cell=torch.eye(3, dtype=self.dtype, device=self.device),
-            ns_mesh=torch.ones(3, dtype=int, device=self.device),
+            cell=cell,
+            ns_mesh=ns_mesh,
             interpolation_nodes=self.interpolation_nodes,
             kernel=self.potential,
             mode=0,  # Green's function for point-charge potentials
@@ -78,8 +81,8 @@ class P3MCalculator(PMECalculator):
         )
 
         self.mesh_interpolator: MeshInterpolator = MeshInterpolator(
-            cell=torch.eye(3, dtype=self.dtype, device=self.device),
-            ns_mesh=torch.ones(3, dtype=int, device=self.device),
+            cell=cell,
+            ns_mesh=ns_mesh,
             interpolation_nodes=self.interpolation_nodes,
             method="P3M",
         )

--- a/src/torchpme/calculators/p3m.py
+++ b/src/torchpme/calculators/p3m.py
@@ -42,8 +42,6 @@ class P3MCalculator(PMECalculator):
         set to :py:obj:`False`, a "half" neighbor list is expected.
     :param prefactor: electrostatics prefactor; see :ref:`prefactors` for details and
         common values.
-    :param dtype: type used for the internal buffers and parameters
-    :param device: device used for the internal buffers and parameters
 
     For an **example** on the usage for any calculator refer to :ref:`userdoc-how-to`.
     """
@@ -55,8 +53,6 @@ class P3MCalculator(PMECalculator):
         interpolation_nodes: int = 4,
         full_neighbor_list: bool = False,
         prefactor: float = 1.0,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
         self.mesh_spacing: float = mesh_spacing
 
@@ -68,8 +64,6 @@ class P3MCalculator(PMECalculator):
             potential=potential,
             full_neighbor_list=full_neighbor_list,
             prefactor=prefactor,
-            dtype=dtype,
-            device=device,
         )
 
         self.kspace_filter: P3MKSpaceFilter = P3MKSpaceFilter(

--- a/src/torchpme/calculators/p3m.py
+++ b/src/torchpme/calculators/p3m.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import torch
 
 from ..lib.kspace_filter import P3MKSpaceFilter
@@ -66,7 +64,11 @@ class P3MCalculator(PMECalculator):
             prefactor=prefactor,
         )
 
-        cell = torch.eye(3, device=self.potential.smearing.device, dtype=self.potential.smearing.dtype)
+        cell = torch.eye(
+            3,
+            device=self.potential.smearing.device,
+            dtype=self.potential.smearing.dtype,
+        )
         ns_mesh = torch.ones(3, dtype=int, device=cell.device)
 
         self.kspace_filter: P3MKSpaceFilter = P3MKSpaceFilter(

--- a/src/torchpme/calculators/p3m.py
+++ b/src/torchpme/calculators/p3m.py
@@ -64,6 +64,11 @@ class P3MCalculator(PMECalculator):
             prefactor=prefactor,
         )
 
+        if potential.smearing is None:
+            raise ValueError(
+                "Must specify smearing to use a potential with P3MCalculator"
+            )
+
         cell = torch.eye(
             3,
             device=self.potential.smearing.device,

--- a/src/torchpme/calculators/pme.py
+++ b/src/torchpme/calculators/pme.py
@@ -70,11 +70,11 @@ class PMECalculator(Calculator):
 
         self.mesh_spacing: float = mesh_spacing
 
-        self.register_buffer("cell", torch.eye(3))
-        ns_mesh = torch.ones(3, dtype=int, device=self.cell.device)
+        cell = torch.eye(3, device=self.potential.smearing.device, dtype=self.potential.smearing.dtype)
+        ns_mesh = torch.ones(3, dtype=int, device=cell.device)
 
         self.kspace_filter: KSpaceFilter = KSpaceFilter(
-            cell=self.cell,
+            cell=cell,
             ns_mesh=ns_mesh,
             kernel=self.potential,
             fft_norm="backward",
@@ -84,7 +84,7 @@ class PMECalculator(Calculator):
         self.interpolation_nodes: int = interpolation_nodes
 
         self.mesh_interpolator: MeshInterpolator = MeshInterpolator(
-            cell=self.cell,
+            cell=cell,
             ns_mesh=ns_mesh,
             interpolation_nodes=self.interpolation_nodes,
             method="Lagrange",  # convention for classic PME

--- a/src/torchpme/calculators/pme.py
+++ b/src/torchpme/calculators/pme.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import torch
 from torch import profiler
 
@@ -70,7 +68,11 @@ class PMECalculator(Calculator):
 
         self.mesh_spacing: float = mesh_spacing
 
-        cell = torch.eye(3, device=self.potential.smearing.device, dtype=self.potential.smearing.dtype)
+        cell = torch.eye(
+            3,
+            device=self.potential.smearing.device,
+            dtype=self.potential.smearing.dtype,
+        )
         ns_mesh = torch.ones(3, dtype=int, device=cell.device)
 
         self.kspace_filter: KSpaceFilter = KSpaceFilter(

--- a/src/torchpme/calculators/pme.py
+++ b/src/torchpme/calculators/pme.py
@@ -63,7 +63,7 @@ class PMECalculator(Calculator):
 
         if potential.smearing is None:
             raise ValueError(
-                "Must specify smearing to use a potential with EwaldCalculator"
+                "Must specify smearing to use a potential with PMECalculator"
             )
 
         self.mesh_spacing: float = mesh_spacing

--- a/src/torchpme/lib/splines.py
+++ b/src/torchpme/lib/splines.py
@@ -151,30 +151,25 @@ def _solve_tridiagonal(a, b, c, d):
 def compute_second_derivatives(
     x_points: torch.Tensor,
     y_points: torch.Tensor,
-    high_precision: Optional[bool] = True,
 ):
     """
     Computes second derivatives given the grid points of a cubic spline.
 
     :param x_points: Abscissas of the splining points for the real-space function
     :param y_points: Ordinates of the splining points for the real-space function
-    :param high_accuracy: bool, perform calculation in double precision
 
     :return: The second derivatives for the spline points
     """
     # Do the calculation in float64 if required
     x = x_points
     y = y_points
-    if high_precision:
-        x = x.to(dtype=torch.float64)
-        y = y.to(dtype=torch.float64)
 
     # Calculate intervals
     intervals = x[1:] - x[:-1]
     dy = (y[1:] - y[:-1]) / intervals
 
     # Create zero boundary conditions (natural spline)
-    d2y = torch.zeros_like(x)
+    torch.zeros_like(x)
 
     n = len(x)
     a = torch.zeros_like(x)  # Sub-diagonal (a[1..n-1])
@@ -195,10 +190,9 @@ def compute_second_derivatives(
         c[i] = intervals[i] / 6
         d[i] = dy[i] - dy[i - 1]
 
-    d2y = _solve_tridiagonal(a, b, c, d)
+    return _solve_tridiagonal(a, b, c, d)
 
     # Converts back to the original dtype
-    return d2y
 
 
 def compute_spline_ft(
@@ -206,7 +200,6 @@ def compute_spline_ft(
     x_points: torch.Tensor,
     y_points: torch.Tensor,
     d2y_points: torch.Tensor,
-    high_precision: Optional[bool] = True,
 ):
     r"""
     Computes the Fourier transform of a splined radial function.
@@ -228,7 +221,6 @@ def compute_spline_ft(
     :param x_points: Abscissas of the splining points for the real-space function
     :param y_points: Ordinates of the splining points for the real-space function
     :param d2y_points:  Second derivatives for the spline points
-    :param high_accuracy: bool, perform calculation in double precision
 
     :return: The radial Fourier transform :math:`\hat{f}(k)` computed
         at the ``k_points`` provided.
@@ -244,8 +236,6 @@ def compute_spline_ft(
 
     # chooses precision for the FT evaluation
     dtype = x_points.dtype
-    if high_precision:
-        dtype = torch.float64
 
     # broadcast to compute at once on all k values.
     # all these are terms that enter the analytical integral.

--- a/src/torchpme/lib/splines.py
+++ b/src/torchpme/lib/splines.py
@@ -127,8 +127,8 @@ def _solve_tridiagonal(a, b, c, d):
     """
     n = len(d)
     # Create copies to avoid modifying the original arrays
-    c_prime = torch.zeros(n)
-    d_prime = torch.zeros(n)
+    c_prime = torch.zeros_like(d)
+    d_prime = torch.zeros_like(d)
 
     # Initial coefficients
     c_prime[0] = c[0] / b[0]
@@ -141,7 +141,7 @@ def _solve_tridiagonal(a, b, c, d):
         d_prime[i] = (d[i] - a[i] * d_prime[i - 1]) / denom
 
     # Backward substitution
-    x = torch.zeros(n)
+    x = torch.zeros_like(d)
     x[-1] = d_prime[-1]
     for i in reversed(range(n - 1)):
         x[i] = d_prime[i] - c_prime[i] * x[i + 1]
@@ -174,13 +174,13 @@ def compute_second_derivatives(
     dy = (y[1:] - y[:-1]) / intervals
 
     # Create zero boundary conditions (natural spline)
-    d2y = torch.zeros_like(x, dtype=torch.float64)
+    d2y = torch.zeros_like(x)
 
     n = len(x)
-    a = torch.zeros(n)  # Sub-diagonal (a[1..n-1])
-    b = torch.zeros(n)  # Main diagonal (b[0..n-1])
-    c = torch.zeros(n)  # Super-diagonal (c[0..n-2])
-    d = torch.zeros(n)  # Right-hand side (d[0..n-1])
+    a = torch.zeros_like(x)  # Sub-diagonal (a[1..n-1])
+    b = torch.zeros_like(x)  # Main diagonal (b[0..n-1])
+    c = torch.zeros_like(x)  # Super-diagonal (c[0..n-2])
+    d = torch.zeros_like(x)  # Right-hand side (d[0..n-1])
 
     # Natural spline boundary conditions
     b[0] = 1
@@ -198,7 +198,7 @@ def compute_second_derivatives(
     d2y = _solve_tridiagonal(a, b, c, d)
 
     # Converts back to the original dtype
-    return d2y.to(dtype=x_points.dtype, device=x_points.device)
+    return d2y
 
 
 def compute_spline_ft(

--- a/src/torchpme/lib/splines.py
+++ b/src/torchpme/lib/splines.py
@@ -168,9 +168,6 @@ def compute_second_derivatives(
     intervals = x[1:] - x[:-1]
     dy = (y[1:] - y[:-1]) / intervals
 
-    # Create zero boundary conditions (natural spline)
-    torch.zeros_like(x)
-
     n = len(x)
     a = torch.zeros_like(x)  # Sub-diagonal (a[1..n-1])
     b = torch.zeros_like(x)  # Main diagonal (b[0..n-1])

--- a/src/torchpme/potentials/combined.py
+++ b/src/torchpme/potentials/combined.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 

--- a/src/torchpme/potentials/combined.py
+++ b/src/torchpme/potentials/combined.py
@@ -27,8 +27,6 @@ class CombinedPotential(Potential):
     :param exclusion_radius: A length scale that defines a *local environment* within
         which the potential should be smoothly zeroed out, as it will be described by a
         separate model.
-    :param dtype: type used for the internal buffers and parameters
-    :param device: device used for the internal buffers and parameters
     """
 
     def __init__(

--- a/src/torchpme/potentials/combined.py
+++ b/src/torchpme/potentials/combined.py
@@ -38,14 +38,10 @@ class CombinedPotential(Potential):
         learnable_weights: Optional[bool] = True,
         smearing: Optional[float] = None,
         exclusion_radius: Optional[float] = None,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
         super().__init__(
             smearing=smearing,
             exclusion_radius=exclusion_radius,
-            dtype=dtype,
-            device=device,
         )
 
         smearings = [pot.smearing for pot in potentials]
@@ -73,9 +69,7 @@ class CombinedPotential(Potential):
                     "The number of initial weights must match the number of potentials being combined"
                 )
         else:
-            initial_weights = torch.ones(
-                len(potentials), dtype=self.dtype, device=self.device
-            )
+            initial_weights = torch.ones(len(potentials))
         # for torchscript
         self.potentials = torch.nn.ModuleList(potentials)
         if learnable_weights:

--- a/src/torchpme/potentials/coulomb.py
+++ b/src/torchpme/potentials/coulomb.py
@@ -26,8 +26,6 @@ class CoulombPotential(Potential):
     :param exclusion_radius: A length scale that defines a *local environment* within
         which the potential should be smoothly zeroed out, as it will be described by a
         separate model.
-    :param dtype: type used for the internal buffers and parameters
-    :param device: device used for the internal buffers and parameters
     """
 
     def __init__(

--- a/src/torchpme/potentials/coulomb.py
+++ b/src/torchpme/potentials/coulomb.py
@@ -34,20 +34,18 @@ class CoulombPotential(Potential):
         self,
         smearing: Optional[float] = None,
         exclusion_radius: Optional[float] = None,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
-        super().__init__(smearing, exclusion_radius, dtype, device)
+        super().__init__(smearing, exclusion_radius)
 
         # constants used in the forwward
         self.register_buffer(
             "_rsqrt2",
-            torch.rsqrt(torch.tensor(2.0, dtype=self.dtype, device=self.device)),
+            torch.rsqrt(torch.tensor(2.0)),
         )
         self.register_buffer(
             "_sqrt_2_on_pi",
             torch.sqrt(
-                torch.tensor(2.0 / torch.pi, dtype=self.dtype, device=self.device)
+                torch.tensor(2.0 / torch.pi)
             ),
         )
 

--- a/src/torchpme/potentials/coulomb.py
+++ b/src/torchpme/potentials/coulomb.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
@@ -59,7 +59,7 @@ class CoulombPotential(Potential):
                 "Cannot compute long-range contribution without specifying `smearing`."
             )
 
-        return torch.erf(dist / self.smearing / 2.0 ** 0.5) / dist
+        return torch.erf(dist / self.smearing / 2.0**0.5) / dist
 
     def lr_from_k_sq(self, k_sq: torch.Tensor) -> torch.Tensor:
         r"""

--- a/src/torchpme/potentials/coulomb.py
+++ b/src/torchpme/potentials/coulomb.py
@@ -37,18 +37,6 @@ class CoulombPotential(Potential):
     ):
         super().__init__(smearing, exclusion_radius)
 
-        # constants used in the forwward
-        self.register_buffer(
-            "_rsqrt2",
-            torch.rsqrt(torch.tensor(2.0)),
-        )
-        self.register_buffer(
-            "_sqrt_2_on_pi",
-            torch.sqrt(
-                torch.tensor(2.0 / torch.pi)
-            ),
-        )
-
     def from_dist(self, dist: torch.Tensor) -> torch.Tensor:
         """
         Full :math:`1/r` potential as a function of :math:`r`.
@@ -73,7 +61,7 @@ class CoulombPotential(Potential):
                 "Cannot compute long-range contribution without specifying `smearing`."
             )
 
-        return torch.erf(dist * (self._rsqrt2 / self.smearing)) / dist
+        return torch.erf(dist / self.smearing / 2.0 ** 0.5) / dist
 
     def lr_from_k_sq(self, k_sq: torch.Tensor) -> torch.Tensor:
         r"""
@@ -103,7 +91,7 @@ class CoulombPotential(Potential):
             raise ValueError(
                 "Cannot compute self contribution without specifying `smearing`."
             )
-        return self._sqrt_2_on_pi / self.smearing
+        return (2 / torch.pi) ** 0.5 / self.smearing
 
     def background_correction(self) -> torch.Tensor:
         # "charge neutrality" correction for 1/r potential

--- a/src/torchpme/potentials/coulomb.py
+++ b/src/torchpme/potentials/coulomb.py
@@ -77,8 +77,6 @@ class CoulombPotential(Potential):
         # https://github.com/jax-ml/jax/issues/1052
         # https://github.com/tensorflow/probability/blob/main/discussion/where-nan.pdf
         masked = torch.where(k_sq == 0, 1.0, k_sq)
-        print(self.smearing.device)
-        print(k_sq.device)
         return torch.where(
             k_sq == 0,
             0.0,

--- a/src/torchpme/potentials/coulomb.py
+++ b/src/torchpme/potentials/coulomb.py
@@ -77,6 +77,8 @@ class CoulombPotential(Potential):
         # https://github.com/jax-ml/jax/issues/1052
         # https://github.com/tensorflow/probability/blob/main/discussion/where-nan.pdf
         masked = torch.where(k_sq == 0, 1.0, k_sq)
+        print(self.smearing.device)
+        print(k_sq.device)
         return torch.where(
             k_sq == 0,
             0.0,

--- a/src/torchpme/potentials/inversepowerlaw.py
+++ b/src/torchpme/potentials/inversepowerlaw.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 from torch.special import gammainc
@@ -43,9 +43,7 @@ class InversePowerLawPotential(Potential):
 
         # function call to check the validity of the exponent
         gammaincc_over_powerlaw(exponent, torch.tensor(1.0))
-        self.register_buffer(
-            "exponent", torch.tensor(float(exponent))
-        )
+        self.register_buffer("exponent", torch.tensor(exponent, dtype=torch.float64))
 
     @torch.jit.export
     def from_dist(self, dist: torch.Tensor) -> torch.Tensor:
@@ -99,7 +97,9 @@ class InversePowerLawPotential(Potential):
             )
 
         peff = (3 - self.exponent) / 2
-        prefac = torch.pi**1.5 / gamma(self.exponent / 2) * (2 * self.smearing**2) ** peff
+        prefac = (
+            torch.pi**1.5 / gamma(self.exponent / 2) * (2 * self.smearing**2) ** peff
+        )
         x = 0.5 * self.smearing**2 * k_sq
 
         # The k=0 term often needs to be set separately since for exponents p<=3

--- a/src/torchpme/potentials/inversepowerlaw.py
+++ b/src/torchpme/potentials/inversepowerlaw.py
@@ -31,8 +31,6 @@ class InversePowerLawPotential(Potential):
     :param: exclusion_radius: float or torch.Tensor containing the length scale
         corresponding to a local environment. See also
         :class:`Potential`.
-    :param dtype: type used for the internal buffers and parameters
-    :param device: device used for the internal buffers and parameters
     """
 
     def __init__(
@@ -40,15 +38,13 @@ class InversePowerLawPotential(Potential):
         exponent: int,
         smearing: Optional[float] = None,
         exclusion_radius: Optional[float] = None,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
-        super().__init__(smearing, exclusion_radius, dtype, device)
+        super().__init__(smearing, exclusion_radius)
 
         # function call to check the validity of the exponent
-        gammaincc_over_powerlaw(exponent, torch.tensor(1.0, dtype=dtype, device=device))
+        gammaincc_over_powerlaw(exponent, torch.tensor(1.0))
         self.register_buffer(
-            "exponent", torch.tensor(exponent, dtype=self.dtype, device=self.device)
+            "exponent", torch.tensor(exponent)
         )
 
     @torch.jit.export

--- a/src/torchpme/potentials/inversepowerlaw.py
+++ b/src/torchpme/potentials/inversepowerlaw.py
@@ -44,7 +44,7 @@ class InversePowerLawPotential(Potential):
         # function call to check the validity of the exponent
         gammaincc_over_powerlaw(exponent, torch.tensor(1.0))
         self.register_buffer(
-            "exponent", torch.tensor(exponent)
+            "exponent", torch.tensor(float(exponent))
         )
 
     @torch.jit.export

--- a/src/torchpme/potentials/potential.py
+++ b/src/torchpme/potentials/potential.py
@@ -38,19 +38,8 @@ class Potential(torch.nn.Module):
     ):
         super().__init__()
 
-        if smearing is not None:
-            self.register_buffer(
-                "smearing", torch.tensor(smearing)
-            )
-        else:
-            self.smearing = None
-        if exclusion_radius is not None:
-            self.register_buffer(
-                "exclusion_radius",
-                torch.tensor(exclusion_radius),
-            )
-        else:
-            self.exclusion_radius = None
+        self.smearing = smearing
+        self.exclusion_radius = exclusion_radius
 
     @torch.jit.export
     def f_cutoff(self, dist: torch.Tensor) -> torch.Tensor:

--- a/src/torchpme/potentials/potential.py
+++ b/src/torchpme/potentials/potential.py
@@ -1,6 +1,7 @@
-from typing import Optional, Union
+from typing import Optional
 
 import torch
+
 
 class Potential(torch.nn.Module):
     r"""
@@ -39,7 +40,9 @@ class Potential(torch.nn.Module):
         super().__init__()
 
         if smearing is not None:
-            self.register_buffer("smearing", torch.tensor(smearing))
+            self.register_buffer(
+                "smearing", torch.tensor(smearing, dtype=torch.float64)
+            )
         else:
             self.smearing = None
 

--- a/src/torchpme/potentials/potential.py
+++ b/src/torchpme/potentials/potential.py
@@ -38,7 +38,11 @@ class Potential(torch.nn.Module):
     ):
         super().__init__()
 
-        self.smearing = smearing
+        if smearing is not None:
+            self.register_buffer("smearing", torch.tensor(smearing))
+        else:
+            self.smearing = None
+
         self.exclusion_radius = exclusion_radius
 
     @torch.jit.export

--- a/src/torchpme/potentials/potential.py
+++ b/src/torchpme/potentials/potential.py
@@ -2,9 +2,6 @@ from typing import Optional, Union
 
 import torch
 
-from .._utils import _get_device, _get_dtype
-
-
 class Potential(torch.nn.Module):
     r"""
     Base class defining the interface for a pair potential energy function
@@ -32,32 +29,25 @@ class Potential(torch.nn.Module):
     :param exclusion_radius: A length scale that defines a *local environment* within
         which the potential should be smoothly zeroed out, as it will be described by a
         separate model.
-    :param dtype: type used for the internal buffers and parameters
-    :param device: device used for the internal buffers and parameters
     """
 
     def __init__(
         self,
         smearing: Optional[float] = None,
         exclusion_radius: Optional[float] = None,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
         super().__init__()
 
-        self.device = _get_device(device)
-        self.dtype = _get_dtype(dtype)
-
         if smearing is not None:
             self.register_buffer(
-                "smearing", torch.tensor(smearing, device=self.device, dtype=self.dtype)
+                "smearing", torch.tensor(smearing)
             )
         else:
             self.smearing = None
         if exclusion_radius is not None:
             self.register_buffer(
                 "exclusion_radius",
-                torch.tensor(exclusion_radius, device=self.device, dtype=self.dtype),
+                torch.tensor(exclusion_radius),
             )
         else:
             self.exclusion_radius = None

--- a/src/torchpme/potentials/spline.py
+++ b/src/torchpme/potentials/spline.py
@@ -84,8 +84,8 @@ class SplinePotential(Potential):
                 k_grid = torch.pi * 2 * torch.reciprocal(r_grid).flip(dims=[0])
             else:
                 k_grid = r_grid.clone().detach()
-        else:
-            self.register_buffer("k_grid", k_grid)
+
+        self.register_buffer("k_grid", k_grid)
 
         if yhat_grid is None:
             # computes automatically!
@@ -95,8 +95,8 @@ class SplinePotential(Potential):
                 y_grid,
                 compute_second_derivatives(r_grid, y_grid),
             )
-        else:
-            self.register_buffer("yhat_grid", yhat_grid)
+
+        self.register_buffer("yhat_grid", yhat_grid)
 
         # the function is defined for k**2, so we define the grid accordingly
         if reciprocal:

--- a/src/torchpme/potentials/spline.py
+++ b/src/torchpme/potentials/spline.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
@@ -63,7 +63,7 @@ class SplinePotential(Potential):
 
         if len(y_grid) != len(r_grid):
             raise ValueError("Length of radial grid and value array mismatch.")
-        
+
         self.register_buffer("r_grid", r_grid)
         self.register_buffer("y_grid", y_grid)
 
@@ -106,14 +106,14 @@ class SplinePotential(Potential):
 
         if y_at_zero is None:
             self._y_at_zero = self._spline(
-                torch.zeros(1, dtype=self.dtype, device=self.device)
+                torch.zeros(1, dtype=self.r_grid.dtype, device=self.r_grid.device)
             )
         else:
             self._y_at_zero = y_at_zero
 
         if yhat_at_zero is None:
             self._yhat_at_zero = self._krn_spline(
-                torch.zeros(1, dtype=self.dtype, device=self.device)
+                torch.zeros(1, dtype=self.k_grid.dtype, device=self.k_grid.device)
             )
         else:
             self._yhat_at_zero = yhat_at_zero

--- a/src/torchpme/potentials/spline.py
+++ b/src/torchpme/potentials/spline.py
@@ -42,8 +42,6 @@ class SplinePotential(Potential):
     :param exclusion_radius: A length scale that defines a *local environment* within
         which the potential should be smoothly zeroed out, as it will be described by a
         separate model.
-    :param dtype: type used for the internal buffers and parameters
-    :param device: device used for the internal buffers and parameters
     """
 
     def __init__(

--- a/src/torchpme/tuning/ewald.py
+++ b/src/torchpme/tuning/ewald.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Optional, Union
+from typing import Any
 from warnings import warn
 
 import torch

--- a/src/torchpme/tuning/ewald.py
+++ b/src/torchpme/tuning/ewald.py
@@ -19,8 +19,6 @@ def tune_ewald(
     ns_lo: int = 1,
     ns_hi: int = 14,
     accuracy: float = 1e-3,
-    dtype: Optional[torch.dtype] = None,
-    device: Union[None, str, torch.device] = None,
 ) -> tuple[float, dict[str, Any], float]:
     r"""
     Find the optimal parameters for :class:`torchpme.EwaldCalculator`.
@@ -96,8 +94,6 @@ def tune_ewald(
         calculator=EwaldCalculator,
         error_bounds=EwaldErrorBounds(charges=charges, cell=cell, positions=positions),
         params=params,
-        dtype=dtype,
-        device=device,
     )
     smearing = tuner.estimate_smearing(accuracy)
     errs, timings = tuner.tune(accuracy)

--- a/src/torchpme/tuning/p3m.py
+++ b/src/torchpme/tuning/p3m.py
@@ -79,8 +79,6 @@ def tune_p3m(
     mesh_lo: int = 2,
     mesh_hi: int = 7,
     accuracy: float = 1e-3,
-    dtype: Optional[torch.dtype] = None,
-    device: Union[None, str, torch.device] = None,
 ) -> tuple[float, dict[str, Any], float]:
     r"""
     Find the optimal parameters for :class:`torchpme.calculators.pme.PMECalculator`.
@@ -169,8 +167,6 @@ def tune_p3m(
         calculator=P3MCalculator,
         error_bounds=P3MErrorBounds(charges=charges, cell=cell, positions=positions),
         params=params,
-        dtype=dtype,
-        device=device,
     )
     smearing = tuner.estimate_smearing(accuracy)
     errs, timings = tuner.tune(accuracy)

--- a/src/torchpme/tuning/p3m.py
+++ b/src/torchpme/tuning/p3m.py
@@ -1,6 +1,6 @@
 import math
 from itertools import product
-from typing import Any, Optional, Union
+from typing import Any
 from warnings import warn
 
 import torch

--- a/src/torchpme/tuning/pme.py
+++ b/src/torchpme/tuning/pme.py
@@ -1,6 +1,6 @@
 import math
 from itertools import product
-from typing import Any, Optional, Union
+from typing import Any
 from warnings import warn
 
 import torch

--- a/src/torchpme/tuning/pme.py
+++ b/src/torchpme/tuning/pme.py
@@ -22,8 +22,6 @@ def tune_pme(
     mesh_lo: int = 2,
     mesh_hi: int = 7,
     accuracy: float = 1e-3,
-    dtype: Optional[torch.dtype] = None,
-    device: Union[None, str, torch.device] = None,
 ) -> tuple[float, dict[str, Any], float]:
     r"""
     Find the optimal parameters for :class:`torchpme.PMECalculator`.
@@ -112,8 +110,6 @@ def tune_pme(
         calculator=PMECalculator,
         error_bounds=PMEErrorBounds(charges=charges, cell=cell, positions=positions),
         params=params,
-        dtype=dtype,
-        device=device,
     )
     smearing = tuner.estimate_smearing(accuracy)
     errs, timings = tuner.tune(accuracy)

--- a/src/torchpme/tuning/tuner.py
+++ b/src/torchpme/tuning/tuner.py
@@ -1,6 +1,6 @@
 import math
 import time
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
@@ -234,7 +234,7 @@ class GridSearchTuner(TunerBase):
             ),
             **k_space_params,
         )
-
+        calculator.to(device=self.positions.device, dtype=self.positions.dtype)
         return self.time_func(calculator)
 
 

--- a/src/torchpme/tuning/tuner.py
+++ b/src/torchpme/tuning/tuner.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 
 import torch
 
-from .._utils import _get_device, _get_dtype, _validate_parameters
+from .._utils import _validate_parameters
 from ..calculators import Calculator
 from ..potentials import InversePowerLawPotential
 
@@ -83,16 +83,11 @@ class TunerBase:
         cutoff: float,
         calculator: type[Calculator],
         exponent: int = 1,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
         if exponent != 1:
             raise NotImplementedError(
                 f"Only exponent = 1 is supported but got {exponent}."
             )
-
-        self.device = _get_device(device)
-        self.dtype = _get_dtype(dtype)
 
         _validate_parameters(
             charges=charges,
@@ -103,8 +98,6 @@ class TunerBase:
                 [1.0], device=positions.device, dtype=positions.dtype
             ),
             smearing=1.0,  # dummy value because; always have range-seperated potentials
-            dtype=self.dtype,
-            device=self.device,
         )
         self.charges = charges
         self.cell = cell
@@ -189,8 +182,6 @@ class GridSearchTuner(TunerBase):
         neighbor_indices: torch.Tensor,
         neighbor_distances: torch.Tensor,
         exponent: int = 1,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
         super().__init__(
             charges=charges,
@@ -199,8 +190,6 @@ class GridSearchTuner(TunerBase):
             cutoff=cutoff,
             calculator=calculator,
             exponent=exponent,
-            dtype=dtype,
-            device=device,
         )
         self.error_bounds = error_bounds
         self.params = params
@@ -211,8 +200,6 @@ class GridSearchTuner(TunerBase):
             neighbor_indices,
             neighbor_distances,
             True,
-            dtype=dtype,
-            device=device,
         )
 
     def tune(self, accuracy: float = 1e-3) -> tuple[list[float], list[float]]:
@@ -244,11 +231,7 @@ class GridSearchTuner(TunerBase):
             potential=InversePowerLawPotential(
                 exponent=self.exponent,  # but only exponent = 1 is supported
                 smearing=smearing,
-                device=self.device,
-                dtype=self.dtype,
             ),
-            device=self.device,
-            dtype=self.dtype,
             **k_space_params,
         )
 
@@ -289,13 +272,8 @@ class TuningTimings(torch.nn.Module):
         n_repeat: int = 4,
         n_warmup: int = 4,
         run_backward: Optional[bool] = True,
-        dtype: Optional[torch.dtype] = None,
-        device: Union[None, str, torch.device] = None,
     ):
         super().__init__()
-
-        self.device = _get_device(device)
-        self.dtype = _get_dtype(dtype)
 
         _validate_parameters(
             charges=charges,
@@ -304,8 +282,6 @@ class TuningTimings(torch.nn.Module):
             neighbor_indices=neighbor_indices,
             neighbor_distances=neighbor_distances,
             smearing=1.0,  # dummy value because; always have range-seperated potentials
-            device=self.device,
-            dtype=self.dtype,
         )
 
         self.charges = charges
@@ -351,8 +327,6 @@ class TuningTimings(torch.nn.Module):
             if self.run_backward:
                 value.backward(retain_graph=True)
 
-            if self.device is torch.device("cuda"):
-                torch.cuda.synchronize()
             execution_time += time.monotonic()
 
         return execution_time / self.n_repeat

--- a/tests/calculators/test_calculator.py
+++ b/tests/calculators/test_calculator.py
@@ -43,35 +43,6 @@ def test_compute_output_shapes():
     assert result.shape == charges.shape
 
 
-def test_wrong_device_positions():
-    calculator = CalculatorTest()
-    match = r"device of `positions` \(meta\) must be same as the class device \(cpu\)"
-    with pytest.raises(ValueError, match=match):
-        calculator.forward(
-            positions=POSITIONS_1.to(device="meta"),
-            charges=CHARGES_1,
-            cell=CELL_1,
-            neighbor_indices=NEIGHBOR_INDICES,
-            neighbor_distances=NEIGHBOR_DISTANCES,
-        )
-
-
-def test_wrong_dtype_positions():
-    calculator = CalculatorTest()
-    match = (
-        r"type of `positions` \(torch.float64\) must be same as the class type "
-        r"\(torch.float32\)"
-    )
-    with pytest.raises(TypeError, match=match):
-        calculator.forward(
-            positions=POSITIONS_1.to(dtype=torch.float64),
-            charges=CHARGES_1,
-            cell=CELL_1,
-            neighbor_indices=NEIGHBOR_INDICES,
-            neighbor_distances=NEIGHBOR_DISTANCES,
-        )
-
-
 # Tests for invalid shape, dtype and device of positions
 def test_invalid_shape_positions():
     calculator = CalculatorTest()
@@ -108,7 +79,7 @@ def test_invalid_shape_cell():
 def test_invalid_dtype_cell():
     calculator = CalculatorTest()
     match = (
-        r"type of `cell` \(torch.float64\) must be same as the class \(torch.float32\)"
+        r"type of `cell` \(torch.float64\) must be same as that of the `positions` class \(torch.float32\)"
     )
     with pytest.raises(TypeError, match=match):
         calculator.forward(
@@ -122,7 +93,7 @@ def test_invalid_dtype_cell():
 
 def test_invalid_device_cell():
     calculator = CalculatorTest()
-    match = r"device of `cell` \(meta\) must be same as the class \(cpu\)"
+    match = r"device of `cell` \(meta\) must be same as that of the `positions` class \(cpu\)"
     with pytest.raises(ValueError, match=match):
         calculator.forward(
             positions=POSITIONS_1,
@@ -188,7 +159,7 @@ def test_invalid_shape_charges():
 def test_invalid_dtype_charges():
     calculator = CalculatorTest()
     match = (
-        r"type of `charges` \(torch.float64\) must be same as the class "
+        r"type of `charges` \(torch.float64\) must be same as that of the `positions` class "
         r"\(torch.float32\)"
     )
     with pytest.raises(TypeError, match=match):
@@ -203,7 +174,7 @@ def test_invalid_dtype_charges():
 
 def test_invalid_device_charges():
     calculator = CalculatorTest()
-    match = r"device of `charges` \(meta\) must be same as the class \(cpu\)"
+    match = r"device of `charges` \(meta\) must be same as that of the `positions` class \(cpu\)"
     with pytest.raises(ValueError, match=match):
         calculator.forward(
             positions=POSITIONS_1,
@@ -248,7 +219,7 @@ def test_invalid_shape_neighbor_indices_neighbor_distances():
 
 def test_invalid_device_neighbor_indices():
     calculator = CalculatorTest()
-    match = r"device of `neighbor_indices` \(meta\) must be same as the class \(cpu\)"
+    match = r"device of `neighbor_indices` \(meta\) must be same as that of the `positions` class \(cpu\)"
     with pytest.raises(ValueError, match=match):
         calculator.forward(
             positions=POSITIONS_1,
@@ -261,7 +232,7 @@ def test_invalid_device_neighbor_indices():
 
 def test_invalid_device_neighbor_distances():
     calculator = CalculatorTest()
-    match = r"device of `neighbor_distances` \(meta\) must be same as the class \(cpu\)"
+    match = r"device of `neighbor_distances` \(meta\) must be same as that of the `positions` class \(cpu\)"
     with pytest.raises(ValueError, match=match):
         calculator.forward(
             positions=POSITIONS_1,
@@ -276,7 +247,7 @@ def test_invalid_dtype_neighbor_distances():
     calculator = CalculatorTest()
     match = (
         r"type of `neighbor_distances` \(torch.float64\) must be same "
-        r"as the class \(torch.float32\)"
+        r"as that of the `positions` class \(torch.float32\)"
     )
     with pytest.raises(TypeError, match=match):
         calculator.forward(

--- a/tests/calculators/test_calculator.py
+++ b/tests/calculators/test_calculator.py
@@ -78,9 +78,7 @@ def test_invalid_shape_cell():
 
 def test_invalid_dtype_cell():
     calculator = CalculatorTest()
-    match = (
-        r"type of `cell` \(torch.float64\) must be same as that of the `positions` class \(torch.float32\)"
-    )
+    match = r"type of `cell` \(torch.float64\) must be same as that of the `positions` class \(torch.float32\)"
     with pytest.raises(TypeError, match=match):
         calculator.forward(
             positions=POSITIONS_1,

--- a/tests/calculators/test_values_direct.py
+++ b/tests/calculators/test_values_direct.py
@@ -18,10 +18,9 @@ class CalculatorTest(Calculator):
     def __init__(self, **kwargs):
         super().__init__(
             potential=CoulombPotential(
-                smearing=None, exclusion_radius=None, dtype=DTYPE
+                smearing=None, exclusion_radius=None,
             ),
             **kwargs,
-            dtype=DTYPE,
         )
 
 

--- a/tests/calculators/test_values_direct.py
+++ b/tests/calculators/test_values_direct.py
@@ -18,7 +18,8 @@ class CalculatorTest(Calculator):
     def __init__(self, **kwargs):
         super().__init__(
             potential=CoulombPotential(
-                smearing=None, exclusion_radius=None,
+                smearing=None,
+                exclusion_radius=None,
             ),
             **kwargs,
         )

--- a/tests/calculators/test_values_ewald.py
+++ b/tests/calculators/test_values_ewald.py
@@ -101,9 +101,8 @@ def test_madelung(crystal_name, scaling_factor, calc_name):
         smearing = sr_cutoff / 5.0
         lr_wavelength = 0.5 * smearing
         calc = EwaldCalculator(
-            InversePowerLawPotential(exponent=1, smearing=smearing, dtype=DTYPE),
+            InversePowerLawPotential(exponent=1, smearing=smearing),
             lr_wavelength=lr_wavelength,
-            dtype=DTYPE,
         )
         rtol = 4e-6
     elif calc_name == "pme":
@@ -113,19 +112,16 @@ def test_madelung(crystal_name, scaling_factor, calc_name):
             InversePowerLawPotential(
                 exponent=1,
                 smearing=smearing,
-                dtype=DTYPE,
             ),
             mesh_spacing=smearing / 8,
-            dtype=DTYPE,
         )
         rtol = 9e-4
     elif calc_name == "p3m":
         sr_cutoff = 2 * scaling_factor
         smearing = sr_cutoff / 5.0
         calc = P3MCalculator(
-            CoulombPotential(smearing=smearing, dtype=DTYPE),
+            CoulombPotential(smearing=smearing),
             mesh_spacing=smearing / 8,
-            dtype=DTYPE,
         )
         rtol = 9e-4
 
@@ -133,7 +129,7 @@ def test_madelung(crystal_name, scaling_factor, calc_name):
     neighbor_indices, neighbor_distances = neighbor_list(
         positions=pos, periodic=True, box=cell, cutoff=sr_cutoff
     )
-
+    calc.to(DTYPE)
     # Compute potential and compare against target value using default hypers
     potentials = calc.forward(
         positions=pos,
@@ -200,10 +196,10 @@ def test_wigner(crystal_name, scaling_factor):
 
         # Compute potential and compare against reference
         calc = EwaldCalculator(
-            InversePowerLawPotential(exponent=1, smearing=smeareff, dtype=DTYPE),
+            InversePowerLawPotential(exponent=1, smearing=smeareff),
             lr_wavelength=smeareff / 2,
-            dtype=DTYPE,
         )
+        calc.to(DTYPE)
         potentials = calc.forward(
             positions=positions,
             charges=charges,
@@ -251,28 +247,25 @@ def test_random_structure(
 
     if calc_name == "ewald":
         calc = EwaldCalculator(
-            CoulombPotential(smearing=smearing, dtype=DTYPE),
+            CoulombPotential(smearing=smearing),
             lr_wavelength=0.5 * smearing,
             full_neighbor_list=full_neighbor_list,
             prefactor=torchpme.prefactors.eV_A,
-            dtype=DTYPE,
         )
 
     elif calc_name == "pme":
         calc = PMECalculator(
-            CoulombPotential(smearing=smearing, dtype=DTYPE),
+            CoulombPotential(smearing=smearing),
             mesh_spacing=smearing / 8.0,
             full_neighbor_list=full_neighbor_list,
             prefactor=torchpme.prefactors.eV_A,
-            dtype=DTYPE,
         )
     elif calc_name == "p3m":
         calc = P3MCalculator(
-            CoulombPotential(smearing=smearing, dtype=DTYPE),
+            CoulombPotential(smearing=smearing),
             mesh_spacing=smearing / 8.0,
             full_neighbor_list=full_neighbor_list,
             prefactor=torchpme.prefactors.eV_A,
-            dtype=DTYPE,
         )
 
     neighbor_indices, neighbor_shifts = neighbor_list(
@@ -295,6 +288,7 @@ def test_random_structure(
         neighbor_shifts=neighbor_shifts,
     )
 
+    calc.to(DTYPE)
     potentials = calc.forward(
         positions=positions,
         charges=charges,

--- a/tests/calculators/test_workflow.py
+++ b/tests/calculators/test_workflow.py
@@ -193,3 +193,12 @@ class TestWorkflow:
             TypeError, match="Potential must be an instance of Potential, got.*"
         ):
             CalculatorClass(**params)
+
+    def test_smearing_incompatability(self, CalculatorClass, params, device, dtype):
+        """Test that the calculator raises an error if the potential and calculator are incompatible."""
+        if type(CalculatorClass) in [EwaldCalculator, PMECalculator, P3MCalculator]:
+            params["smearing"] = None
+            with pytest.raises(
+                TypeError, match="Must specify smearing to use a potential with .*"
+            ):
+                CalculatorClass(**params)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,8 +7,6 @@ from typing import Optional
 import torch
 from vesin import NeighborList
 
-from torchpme._utils import _get_device, _get_dtype
-
 SQRT3 = math.sqrt(3)
 
 DIR_PATH = Path(__file__).parent
@@ -17,8 +15,6 @@ COULOMB_TEST_FRAMES = EXAMPLES / "coulomb_test_frames.xyz"
 
 
 def define_crystal(crystal_name="CsCl", dtype=None, device=None):
-    device = _get_device(device)
-    dtype = _get_dtype(dtype)
 
     # Define all relevant parameters (atom positions, charges, cell) of the reference
     # crystal structures for which the Madelung constants obtained from the Ewald sums

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,6 @@ COULOMB_TEST_FRAMES = EXAMPLES / "coulomb_test_frames.xyz"
 
 
 def define_crystal(crystal_name="CsCl", dtype=None, device=None):
-
     # Define all relevant parameters (atom positions, charges, cell) of the reference
     # crystal structures for which the Madelung constants obtained from the Ewald sums
     # are compared with reference values.

--- a/tests/lib/test_splines.py
+++ b/tests/lib/test_splines.py
@@ -59,8 +59,12 @@ def test_inverse_spline(function):
 
 @pytest.mark.parametrize("high_accuracy", [True, False])
 def test_ft_accuracy(high_accuracy):
-    x_grid = torch.linspace(0, 20, 2000, dtype=torch.float32)
-    y_grid = torch.exp(-(x_grid**2) * 0.5)
+    if high_accuracy:
+        x_grid = torch.linspace(0, 20, 2000, dtype=torch.float64)
+        y_grid = torch.exp(-(x_grid**2) * 0.5)
+    else:
+        x_grid = torch.linspace(0, 20, 2000, dtype=torch.float32)
+        y_grid = torch.exp(-(x_grid**2) * 0.5)
 
     k_grid = torch.linspace(0, 20, 20, dtype=torch.float32)
     krn = compute_spline_ft(
@@ -68,9 +72,9 @@ def test_ft_accuracy(high_accuracy):
         x_points=x_grid,
         y_points=y_grid,
         d2y_points=compute_second_derivatives(
-            x_points=x_grid, y_points=y_grid, high_precision=high_accuracy
+            x_points=x_grid,
+            y_points=y_grid,
         ),
-        high_precision=high_accuracy,
     )
 
     krn_ref = torch.exp(-(k_grid**2) * 0.5) * (2 * torch.pi) ** (3 / 2)

--- a/tests/tuning/test_timer.py
+++ b/tests/tuning/test_timer.py
@@ -41,7 +41,6 @@ def test_timer():
     calculator = EwaldCalculator(
         potential=CoulombPotential(smearing=1.0),
         lr_wavelength=0.25,
-        dtype=DTYPE,
     )
 
     timing_1 = TuningTimings(
@@ -50,7 +49,6 @@ def test_timer():
         positions=pos,
         neighbor_indices=neighbor_indices,
         neighbor_distances=neighbor_distances,
-        dtype=DTYPE,
         n_repeat=n_repeat_1,
     )
 
@@ -60,7 +58,6 @@ def test_timer():
         positions=pos,
         neighbor_indices=neighbor_indices,
         neighbor_distances=neighbor_distances,
-        dtype=DTYPE,
         n_repeat=n_repeat_2,
     )
 


### PR DESCRIPTION
A couple of PRs ago, we decided to include `dtype` and `device` as explicit and obligatory parameters for both `calculators` and `potentials`.

Unfortunately, after thorough consideration of how typical pipelines are built, I concluded that we should abandon this design choice.

The main reason is that, in most cases, when working with an NN `model,` the preferred strategy is to first initialize the `model` and then move it to the desired device using `model.to(device)`.

Since `torch-pme` is designed to be an internal part of the `model`, this creates a conflict. We initialize `dtype` and `device` once, but when we later move the `model` to a different `device`, it undermines our prior device-checking logic.

Luckily, since our entire pipeline is either a `torch.nn.Module` or its subclass, we can integrate it smoothly with models that change their `device` and `dtype`. The key idea is to thoroughly rewrite the pipeline so that all newly created tensors during calculations are registered as buffers using `self.register_buffer`.

This PR aims to achieve exactly that.

<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--166.org.readthedocs.build/en/166/

<!-- readthedocs-preview torch-pme end -->