### PR TITLE
Add a built-in filter for NL calculation results

### DIFF
--- a/src/torchpme/tuning/tuner.py
+++ b/src/torchpme/tuning/tuner.py
@@ -137,6 +137,25 @@ class TunerBase:
 
         return float(smearing)
 
+    @staticmethod
+    def filter_neighbors(
+        cutoff: float, neighbor_indices: torch.Tensor, neighbor_distances: torch.Tensor
+    ):
+        """
+        Filter neighbor indices and distances based on a user given cutoff. This allows
+        users pre-computing the neighbor list with a larger cutoff and then filtering
+        the neighbors based on a smaller cutoff, leading to a faster tuning on the
+        cutoff.
+
+        :param cutoff: real space cutoff
+        :param neighbor_indices: torch.tensor with the ``i,j`` indices of neighbors for
+            which the potential should be computed in real space.
+        :param neighbor_distances: torch.tensor with the pair distances of the neighbors
+            for which the potential should be computed in real space."""
+
+        filter_idx = torch.where(neighbor_distances <= cutoff)
+        return neighbor_indices[filter_idx], neighbor_distances[filter_idx]
+
 
 class GridSearchTuner(TunerBase):
     """
@@ -193,6 +212,9 @@ class GridSearchTuner(TunerBase):
         )
         self.error_bounds = error_bounds
         self.params = params
+        neighbor_indices, neighbor_distances = self.filter_neighbors(
+            cutoff, neighbor_indices, neighbor_distances
+        )
         self.time_func = TuningTimings(
             charges,
             cell,

--- a/src/torchpme/tuning/tuner.py
+++ b/src/torchpme/tuning/tuner.py
@@ -153,7 +153,7 @@ class TunerBase:
         :param neighbor_distances: torch.tensor with the pair distances of the neighbors
             for which the potential should be computed in real space.
         """
-        filter_idx = torch.where(neighbor_distances <= cutoff)
+        filter_idx = torch.where(neighbor_distances < cutoff)
         return neighbor_indices[filter_idx], neighbor_distances[filter_idx]
 
 

--- a/src/torchpme/tuning/tuner.py
+++ b/src/torchpme/tuning/tuner.py
@@ -151,8 +151,8 @@ class TunerBase:
         :param neighbor_indices: torch.tensor with the ``i,j`` indices of neighbors for
             which the potential should be computed in real space.
         :param neighbor_distances: torch.tensor with the pair distances of the neighbors
-            for which the potential should be computed in real space."""
-
+            for which the potential should be computed in real space.
+        """
         filter_idx = torch.where(neighbor_distances <= cutoff)
         return neighbor_indices[filter_idx], neighbor_distances[filter_idx]
 

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -120,7 +120,12 @@ def test_cutoff_filter(device, dtype):
     _, filtered_distances = TunerBase.filter_neighbors(
         DEFAULT_CUTOFF, neighbor_indices, neighbor_distances
     )
-    assert filtered_distances.max() <= DEFAULT_CUTOFF
+    assert filtered_distances.max() < DEFAULT_CUTOFF
+
+    _, distance_from_calculation = neighbor_list(
+        positions=positions, box=cell, cutoff=DEFAULT_CUTOFF
+    )
+    assert torch.allclose(filtered_distances, distance_from_calculation)
 
 
 @pytest.mark.parametrize("tune", [tune_ewald, tune_pme, tune_p3m])

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -104,6 +104,25 @@ def test_parameter_choose(device, dtype, calculator, tune, param_length, accurac
     torch.testing.assert_close(madelung, madelung_ref, atol=0, rtol=accuracy)
 
 
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_cutoff_filter(device, dtype):
+    """
+    Check that `TunerBase` initilizes correctly.
+
+    We are using dummy `neighbor_indices` and `neighbor_distances` to verify types. Have
+    to be sure that these dummy variables are initilized correctly.
+    """
+    _, cell, positions = system(device, dtype)
+    neighbor_indices, neighbor_distances = neighbor_list(
+        positions=positions, box=cell, cutoff=DEFAULT_CUTOFF * 10
+    )
+    _, filtered_distances = TunerBase.filter_neighbors(
+        DEFAULT_CUTOFF, neighbor_indices, neighbor_distances
+    )
+    assert filtered_distances.max() <= DEFAULT_CUTOFF
+
+
 @pytest.mark.parametrize("tune", [tune_ewald, tune_pme, tune_p3m])
 def test_accuracy_error(tune):
     pos, charges, cell, _, _ = define_crystal()


### PR DESCRIPTION
This allows users pre-computing the neighbor list with a larger `cutoff` and then filtering the neighbors based on a smaller `cutoff`, leading to a faster tuning on the `cutoff`.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--167.org.readthedocs.build/en/167/

<!-- readthedocs-preview torch-pme end -->