### PR TITLE
Allow the tuning function passing `full_neighbor_list` and `prefactor` to the calculator

### DIFF
--- a/docs/src/references/changelog.rst
+++ b/docs/src/references/changelog.rst
@@ -24,6 +24,11 @@ changelog <https://keepachangelog.com/en/1.1.0/>`_ format. This project follows
 `Unreleased <https://github.com/lab-cosmo/torch-pme/>`_
 -------------------------------------------------------
 
+Added
+#####
+
+* Allow passing `full_neighbor_list` and `prefactor` to tuning functions
+
 `Version 0.3.0 <https://github.com/lab-cosmo/torch-pme/releases/tag/v0.3.0>`_ - 2025-02-21
 ------------------------------------------------------------------------------------------
 

--- a/docs/src/references/changelog.rst
+++ b/docs/src/references/changelog.rst
@@ -27,7 +27,7 @@ changelog <https://keepachangelog.com/en/1.1.0/>`_ format. This project follows
 Added
 #####
 
-* Allow passing `full_neighbor_list` and `prefactor` to tuning functions
+* Allow passing ``full_neighbor_list`` and ``prefactor`` to tuning functions
 
 `Version 0.3.0 <https://github.com/lab-cosmo/torch-pme/releases/tag/v0.3.0>`_ - 2025-02-21
 ------------------------------------------------------------------------------------------

--- a/src/torchpme/tuning/ewald.py
+++ b/src/torchpme/tuning/ewald.py
@@ -15,6 +15,8 @@ def tune_ewald(
     cutoff: float,
     neighbor_indices: torch.Tensor,
     neighbor_distances: torch.Tensor,
+    full_neighbor_list: bool = False,
+    prefactor: float = 1.0,
     exponent: int = 1,
     ns_lo: int = 1,
     ns_hi: int = 14,
@@ -47,6 +49,11 @@ def tune_ewald(
         which the potential should be computed in real space.
     :param neighbor_distances: torch.tensor with the pair distances of the neighbors for
         which the potential should be computed in real space.
+    :param full_neighbor_list: If set to :py:obj:`True`, a "full" neighbor list
+        is expected as input. This means that each atom pair appears twice. If
+        set to :py:obj:`False`, a "half" neighbor list is expected.
+    :param prefactor: electrostatics prefactor; see :ref:`prefactors` for details and
+        common values.
     :param ns_lo: Minimum number of spatial resolution along each axis
     :param ns_hi: Maximum number of spatial resolution along each axis
     :param accuracy: Recomended values for a balance between the accuracy and speed is
@@ -91,6 +98,8 @@ def tune_ewald(
         exponent=exponent,
         neighbor_indices=neighbor_indices,
         neighbor_distances=neighbor_distances,
+        full_neighbor_list=full_neighbor_list,
+        prefactor=prefactor,
         calculator=EwaldCalculator,
         error_bounds=EwaldErrorBounds(charges=charges, cell=cell, positions=positions),
         params=params,

--- a/src/torchpme/tuning/p3m.py
+++ b/src/torchpme/tuning/p3m.py
@@ -73,6 +73,8 @@ def tune_p3m(
     cutoff: float,
     neighbor_indices: torch.Tensor,
     neighbor_distances: torch.Tensor,
+    full_neighbor_list: bool = False,
+    prefactor: float = 1.0,
     exponent: int = 1,
     nodes_lo: int = 2,
     nodes_hi: int = 5,
@@ -100,6 +102,11 @@ def tune_p3m(
         which the potential should be computed in real space.
     :param neighbor_distances: torch.tensor with the pair distances of the neighbors for
         which the potential should be computed in real space.
+    :param full_neighbor_list: If set to :py:obj:`True`, a "full" neighbor list
+        is expected as input. This means that each atom pair appears twice. If
+        set to :py:obj:`False`, a "half" neighbor list is expected.
+    :param prefactor: electrostatics prefactor; see :ref:`prefactors` for details and
+        common values.
     :param cutoff: float, cutoff distance for the neighborlist supported
     :param exponent: :math:`p` in :math:`1/r^p` potentials, currently only :math:`p=1`
         is
@@ -164,6 +171,8 @@ def tune_p3m(
         exponent=exponent,
         neighbor_indices=neighbor_indices,
         neighbor_distances=neighbor_distances,
+        full_neighbor_list=full_neighbor_list,
+        prefactor=prefactor,
         calculator=P3MCalculator,
         error_bounds=P3MErrorBounds(charges=charges, cell=cell, positions=positions),
         params=params,

--- a/src/torchpme/tuning/pme.py
+++ b/src/torchpme/tuning/pme.py
@@ -16,6 +16,8 @@ def tune_pme(
     cutoff: float,
     neighbor_indices: torch.Tensor,
     neighbor_distances: torch.Tensor,
+    full_neighbor_list: bool = False,
+    prefactor: float = 1.0,
     exponent: int = 1,
     nodes_lo: int = 3,
     nodes_hi: int = 7,
@@ -44,6 +46,11 @@ def tune_pme(
         which the potential should be computed in real space.
     :param neighbor_distances: torch.tensor with the pair distances of the neighbors for
         which the potential should be computed in real space.
+    :param full_neighbor_list: If set to :py:obj:`True`, a "full" neighbor list
+        is expected as input. This means that each atom pair appears twice. If
+        set to :py:obj:`False`, a "half" neighbor list is expected.
+    :param prefactor: electrostatics prefactor; see :ref:`prefactors` for details and
+        common values.
     :param exponent: :math:`p` in :math:`1/r^p` potentials, currently only :math:`p=1`
         is supported
     :param nodes_lo: Minimum number of interpolation nodes
@@ -107,6 +114,8 @@ def tune_pme(
         exponent=exponent,
         neighbor_indices=neighbor_indices,
         neighbor_distances=neighbor_distances,
+        full_neighbor_list=full_neighbor_list,
+        prefactor=prefactor,
         calculator=PMECalculator,
         error_bounds=PMEErrorBounds(charges=charges, cell=cell, positions=positions),
         params=params,

--- a/tests/calculators/test_values_ewald.py
+++ b/tests/calculators/test_values_ewald.py
@@ -76,7 +76,8 @@ def generate_orthogonal_transformations():
     ],
 )
 @pytest.mark.parametrize("scaling_factor", [1 / 2.0353610, 1.0, 3.4951291])
-def test_madelung(crystal_name, scaling_factor, calc_name):
+@pytest.mark.parametrize("full_neighbor_list", [True, False])
+def test_madelung(crystal_name, scaling_factor, calc_name, full_neighbor_list):
     """
     Check that the Madelung constants obtained from the Ewald sum calculator matches
     the reference values.
@@ -103,6 +104,7 @@ def test_madelung(crystal_name, scaling_factor, calc_name):
         calc = EwaldCalculator(
             InversePowerLawPotential(exponent=1, smearing=smearing),
             lr_wavelength=lr_wavelength,
+            full_neighbor_list=full_neighbor_list,
         )
         rtol = 4e-6
     elif calc_name == "pme":
@@ -114,6 +116,7 @@ def test_madelung(crystal_name, scaling_factor, calc_name):
                 smearing=smearing,
             ),
             mesh_spacing=smearing / 8,
+            full_neighbor_list=full_neighbor_list,
         )
         rtol = 9e-4
     elif calc_name == "p3m":
@@ -122,12 +125,17 @@ def test_madelung(crystal_name, scaling_factor, calc_name):
         calc = P3MCalculator(
             CoulombPotential(smearing=smearing),
             mesh_spacing=smearing / 8,
+            full_neighbor_list=full_neighbor_list,
         )
         rtol = 9e-4
 
     # Compute neighbor list
     neighbor_indices, neighbor_distances = neighbor_list(
-        positions=pos, periodic=True, box=cell, cutoff=sr_cutoff
+        positions=pos,
+        periodic=True,
+        box=cell,
+        cutoff=sr_cutoff,
+        full_neighbor_list=full_neighbor_list,
     )
     calc.to(DTYPE)
     # Compute potential and compare against target value using default hypers

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -114,7 +114,7 @@ def test_parameter_choose(
 
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("full_nl_list", [True, False])
+@pytest.mark.parametrize("full_neighbor_list", [True, False])
 def test_cutoff_filter(device, dtype, full_neighbor_list):
     """
     Check that `TunerBase` initilizes correctly.


### PR DESCRIPTION
This PR allows passing the two parameters to the calculators, and also updates the pytests on different cases of `full_neighbor_list`



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--180.org.readthedocs.build/en/180/

<!-- readthedocs-preview torch-pme end -->