### PR TITLE
Add a nan check for `KSpaceFilter`

### DIFF
--- a/src/torchpme/lib/kspace_filter.py
+++ b/src/torchpme/lib/kspace_filter.py
@@ -178,7 +178,7 @@ class KSpaceFilter(torch.nn.Module):
 
         filter_hat = mesh_hat * self._kfilter
 
-        return torch.fft.irfftn(
+        result = torch.fft.irfftn(
             filter_hat,
             norm=self._ifft_norm,
             dim=dims,
@@ -187,6 +187,14 @@ class KSpaceFilter(torch.nn.Module):
             # well-defined
             s=mesh_values.shape[-3:],
         )
+
+        if torch.isnan(result).any():
+            raise ValueError(
+                "NaNs found in the output of the k-space filter. This is (likely) due to"
+                " a bad setting of `mesh_spacing`. Please try a different value."
+            )
+
+        return result
 
     def _prep_kvectors(
         self, cell: Optional[torch.Tensor], ns_mesh: Optional[torch.Tensor]


### PR DESCRIPTION
It's found that under special combination of the `cell` and `mesh_spacing`, the `P3MKSpaceFilter` returns an all-nan tensor. To help future debugging, I added a check. It checks if there is any nan in the output, and if so, it raises a `ValueError` and suggests the user to try another `mesh_spacing` value.

To reproduce:
```python
import torch
import torchpme


interpolation_nodes = 5

calculator = torchpme.P3MCalculator(
    potential=torchpme.CoulombPotential(smearing=1, exclusion_radius=4.5),
    interpolation_nodes=interpolation_nodes,
    full_neighbor_list=True,
    mesh_spacing=0.5,
)

charges = torch.ones([4,1])
positions = torch.arange(4*3).reshape(4,3).to(torch.float32)
cell = torch.tensor([
    [-2.2958, -0.5882, -0.0797],
    [ 1.3575, -0.2575, -1.9272],
    [ 1.9694, -5.7254,  2.1524]],
)

neighbor_indices = torch.zeros((0, 2), dtype=torch.int64)
neighbor_distances = torch.zeros((0,))

calculator.forward(
    charges=charges,
    positions=positions,
    cell=cell,
    neighbor_indices=neighbor_indices,
    neighbor_distances=neighbor_distances,
)
```



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
