### PR TITLE
Fix gradient recording in Quickstart

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Here is a simple example to get started with *torch-pme*:
    >>> import torchpme
 
    >>> # Single charge in a cubic box
-   >>> positions = torch.zeros((1, 3), requires_grad=True)
+   >>> positions = torch.zeros((1, 3))
    >>> cell = 8 * torch.eye(3)
    >>> charges = torch.tensor([[1.0]])
 
@@ -99,6 +99,9 @@ Here is a simple example to get started with *torch-pme*:
    >>> # Initialize potential and calculator
    >>> potential = torchpme.CoulombPotential(smearing)
    >>> calculator = torchpme.P3MCalculator(potential, **p3m_parameters)
+
+   >>> # Start recording operations done to ``positions``
+   >>> _ = positions.requires_grad_()
 
    >>> # Compute (per-atom) potentials
    >>> potentials = calculator.forward(


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Fixes #188 

The gradient recording was started before the tuning leading to wrong gradients when using `positions.grad`.

Thanks to @YuchiGuo for pointing this out.

# Contributor (creator of pull-request) checklist

 ~- [ ] Tests updated (for new features and bugfixes)?~
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--190.org.readthedocs.build/en/190/

<!-- readthedocs-preview torch-pme end -->