### PR TITLE
 Fix `get_ns_mesh` under `torch.compile` on CUDA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,9 +57,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: python -m pip install tox coverage[toml]
     - name: run Python tests
-      run: |
-        tox -e tests
-        coverage xml
+      run: tox -e tests
+    - name: generate coverage report
+      run: coverage xml
     - name: upload to codecov.io
       uses: codecov/codecov-action@v6
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,12 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+    - name: activate MSVC (for torch.compile)
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        set >> %GITHUB_ENV%
     - run: python -m pip install tox coverage[toml]
     - name: run Python minimal tests
       run: tox -e tests-min
@@ -55,6 +61,12 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+    - name: activate MSVC (for torch.compile / inductor codegen)
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        set >> %GITHUB_ENV%
     - run: python -m pip install tox coverage[toml]
     - name: run Python tests
       run: tox -e tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: activate MSVC (for torch.compile)
       if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        set >> %GITHUB_ENV%
+      uses: ilammy/msvc-dev-cmd@v1
     - run: python -m pip install tox coverage[toml]
     - name: run Python minimal tests
       run: tox -e tests-min
@@ -63,10 +60,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: activate MSVC (for torch.compile / inductor codegen)
       if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        set >> %GITHUB_ENV%
+      uses: ilammy/msvc-dev-cmd@v1
     - run: python -m pip install tox coverage[toml]
     - name: run Python tests
       run: tox -e tests

--- a/src/torchpme/lib/kvectors.py
+++ b/src/torchpme/lib/kvectors.py
@@ -17,8 +17,8 @@ def get_ns_mesh(cell: torch.Tensor, mesh_spacing: float):
     basis_norms = torch.linalg.norm(cell, dim=1)
     ns_approx = basis_norms / mesh_spacing
     ns_actual_approx = 2 * ns_approx + 1  # actual number of mesh points
-    # ns = [nx, ny, nz], closest power of 2 (helps for FT efficiency)
-    return torch.tensor(2).pow(torch.ceil(torch.log2(ns_actual_approx)).long())
+    # ns = [nx, ny, nz], closest power of 2 (helps for FT efficiency).
+    return torch.pow(2, torch.ceil(torch.log2(ns_actual_approx)).long())
 
 
 def _generate_kvectors(

--- a/tests/calculators/test_workflow.py
+++ b/tests/calculators/test_workflow.py
@@ -140,6 +140,17 @@ class TestWorkflow:
         scripted = torch.jit.script(calculator)
         self.check_operation(calculator=scripted, device=device, dtype=dtype)
 
+    # Inductor falls back to eager for the complex FFT ops
+    @pytest.mark.filterwarnings(
+        "ignore:Torchinductor does not support code generation for complex operators"
+    )
+    def test_operation_as_torch_compile(self, CalculatorClass, params, device, dtype):
+        """Run `check_operation` as a `torch.compile`d module."""
+        calculator = CalculatorClass(**params)
+        calculator.to(device=device, dtype=dtype)
+        compiled = torch.compile(calculator)
+        self.check_operation(calculator=compiled, device=device, dtype=dtype)
+
     def test_save_load(self, CalculatorClass, params, device, dtype):
         """Test if the calculator can be saved and loaded."""
         calculator = CalculatorClass(**params)

--- a/tests/lib/test_kvectors.py
+++ b/tests/lib/test_kvectors.py
@@ -1,3 +1,6 @@
+import sys
+from pathlib import Path
+
 import pytest
 import torch
 from torch.testing import assert_close
@@ -5,7 +8,11 @@ from torch.testing import assert_close
 from torchpme.lib import (
     generate_kvectors_for_ewald,
     generate_kvectors_for_mesh,
+    get_ns_mesh,
 )
+
+sys.path.append(str(Path(__file__).parents[1]))
+from helpers import DEVICES
 
 # Generate random cells and mesh parameters
 cells = []
@@ -129,3 +136,13 @@ def test_different_devices_mesh_values_cell(generate_kvectors):
     match = "`ns` and `cell` are not on the same device, got cpu and meta"
     with pytest.raises(ValueError, match=match):
         generate_kvectors(cell=cell, ns=ns)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_get_ns_mesh_on_device(device):
+    """``get_ns_mesh`` must produce a tensor on the same device as ``cell``."""
+    cell = torch.eye(3, device=device) * 10.0
+    ns = get_ns_mesh(cell, 0.5)
+    assert ns.device.type == torch.device(device).type
+    assert ns.shape == (3,)
+    assert (ns > 0).all()


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

`PMECalculator.forward` cannot be `torch.compile`d when using CUDA. The failure is in `get_ns_mesh`:

```python
# src/torchpme/lib/kvectors.py:21
return torch.tensor(2).pow(torch.ceil(torch.log2(ns_actual_approx)).long())
```

```
torch._inductor.exc.InductorError: LoweringException: RuntimeError:
Unhandled FakeTensor Device Propagation for aten.pow.Tensor_Tensor,
found two different devices cpu, cuda:0
```

`torch.tensor(2)` defaults to CPU. `ns_actual_approx` lives on the CUDA device. Eager mode does not care and TorchScript just optimises it away. 


### Minimal not working example

```python
import torch
import torchpme

pot  = torchpme.CoulombPotential(smearing=1.0)
calc = torchpme.PMECalculator(potential=pot, mesh_spacing=0.5)

dev, dt = "cuda", torch.float32
cell    = torch.eye(3, dtype=dt, device=dev) * 10.0
pos     = torch.rand((5, 3), dtype=dt, device=dev) * 10.0
charges = torch.ones((5, 1), dtype=dt, device=dev)
nbr_idx = torch.zeros((0, 2), dtype=torch.long, device=dev)
nbr_dst = torch.zeros((0,), dtype=dt, device=dev)
periodic = torch.tensor([True, True, True], device=dev)

# Eager: OK
calc.forward(charges, cell, positions=pos,
             neighbor_indices=nbr_idx, neighbor_distances=nbr_dst,
             periodic=periodic)

# Compile: InductorError at get_ns_mesh
torch.compile(calc.forward)(
    charges, cell, positions=pos,
    neighbor_indices=nbr_idx, neighbor_distances=nbr_dst, periodic=periodic,
)
```

## Fix

Use a Python int instead of a CPU-resident scalar tensor:

```python
return torch.pow(2, torch.ceil(torch.log2(ns_actual_approx)).long())
```

`torch.pow(Number, Tensor)` is a supported overload. The literal has no device, so the result lands on the same device as the tensor argument.

## Performance

Realistic problem (~1000 charges, 30 Å cube, `mesh_spacing=0.5`) on an RTX 5080, fp32:

| state | eager forward | compiled forward | jit.script forward |
|---|---|---|---|
| **before** (`torch.tensor(2).pow(...)`) | 2.03 ms | - | 1.20 ms |
| **after** (`torch.pow(2, ...)`) | 2.01 ms | 1.36 ms | 1.20 ms |

`torch.compile` now works and delivers a slight improvement. Still slower than TorchScript due to a lot of graph breaks that compile handles less smoothly. Everything else is unaffected.

## Tests

Adds:
- `test_get_ns_mesh_on_device` asserting both that `get_ns_mesh` lands on the correct devise
- `test_get_ns_mesh_torch_compile`, same test as `test_operation_as_torch_script` but for torch compile

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview torch-pme start -->
----
📚 Documentation preview 📚: https://torch-pme--219.org.readthedocs.build/en/219/

<!-- readthedocs-preview torch-pme end -->